### PR TITLE
Added accordion components to widget-editor package

### DIFF
--- a/src/packages/widget-editor/src/components/accordion/component.js
+++ b/src/packages/widget-editor/src/components/accordion/component.js
@@ -1,0 +1,96 @@
+import React, { useState, useRef, useEffect } from "react";
+import styled, { css } from "styled-components";
+
+const StyledAccordion = styled.div`
+  padding-top: 24px;
+  padding-bottom: 24px;
+`;
+
+const StyledAccordionContent = styled.div`
+  display: 'block';
+  max-height: ${props => props.scrollHeight+'px' || '0'};
+  overflow-y: hidden;
+  transition: all 0.2s ease-out;
+  padding-left: 24px;
+  padding-top: ${props => props.scrollHeight ? '18px' : '0' || '0'};
+  padding-bottom: ${props => props.scrollHeight ? '18px' : '0' || '0'};
+`;
+
+const StyledAccordionButton = styled.a`
+  display: block;
+  height: 25px;	
+  color: #393F44;	
+  /* font-family: Lato;	 */
+  font-size: 16px;	
+  font-weight: bold;	
+  line-height: 25px;
+  position: relative;
+  padding-left: 25px;
+  cursor: pointer;
+
+  &:before {
+    content: " ";
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #C32D7B;
+    position: absolute;
+    left: 0;
+    top: 8px;
+  }
+`;
+
+const StyledAccordionSection = styled.div`
+  padding-top: 11px;
+  padding-bottom: 11px;
+  position: relative;
+
+  &:before {
+    content: " ";
+    height: 1px;
+    width:100%;
+    display: block;
+    position: absolute;
+    top: 0;
+    background-color: #D2D3D6;
+    margin-left: 24px;
+  }
+  
+  &:first-child {
+    &:before {
+      display: none;
+    }
+  }
+`;
+
+export const AccordionSection = ({ title, openDefault, children }) => {
+  const contentRef = useRef(null)
+  const [outerHeight, setOuterHeight] = useState(0);
+
+  const clickToTitle = () => {
+    const panel = contentRef.current;
+    const height = outerHeight ? 0 : panel.scrollHeight;
+    setOuterHeight(height);
+  }
+
+  useEffect(() => {
+    if (openDefault) clickToTitle();
+  }, []);
+
+  return (
+    <StyledAccordionSection>
+      <StyledAccordionButton onClick={() => clickToTitle()}>{title}</StyledAccordionButton>
+      <StyledAccordionContent ref={contentRef} scrollHeight={outerHeight} >
+        {children}
+      </StyledAccordionContent>
+    </StyledAccordionSection>
+  )
+}
+
+export const Accordion = ({ children }) => {
+  return (
+    <StyledAccordion>
+      {children}
+    </StyledAccordion>
+  );
+};

--- a/src/packages/widget-editor/src/components/accordion/index.js
+++ b/src/packages/widget-editor/src/components/accordion/index.js
@@ -1,0 +1,3 @@
+// Components
+export * from "./component";
+

--- a/src/packages/widget-editor/src/components/editor-options/component.js
+++ b/src/packages/widget-editor/src/components/editor-options/component.js
@@ -12,6 +12,7 @@ const StyledContainer = styled.div`
   height: calc(100% - ${FOOTER_HEIGHT} - 20px);
   padding: 0 30px;
   margin: 10px 0;
+  overflow-y: scroll;
   ${DEFAULT_BORDER(1, 1, 1, 0)}
 `;
 

--- a/src/packages/widget-editor/src/components/widget-info/component.js
+++ b/src/packages/widget-editor/src/components/widget-info/component.js
@@ -8,11 +8,11 @@ import FormLabel from "styles-common/form-label";
 import Input from "styles-common/input";
 
 import * as helpers from "./helpers";
+import { Accordion, AccordionSection } from 'components/accordion';
 
 const WidgetInfo = ({ theme, configuration, patchConfiguration }) => {
   const [title, setTitle] = useState(configuration.title);
   const [caption, setCaption] = useState(configuration.caption);
-
   const debounceTitle = useDebounce(title, 500);
   const debounceCaption = useDebounce(caption, 500);
 
@@ -40,21 +40,34 @@ const WidgetInfo = ({ theme, configuration, patchConfiguration }) => {
 
   return (
     <FlexContainer>
-      <FormLabel htmlFor="options-title">Title</FormLabel>
-      <Input
-        type="text"
-        name="options-title"
-        value={title}
-        onChange={e => handleOnChange(e.target.value, "title")}
-      />
-      <FormLabel htmlFor="options-title">Caption</FormLabel>
-      <Input
-        type="text"
-        name="options-capton"
-        value={caption}
-        onChange={e => handleOnChange(e.target.value, "caption")}
-      />
+      <Accordion>
+        <AccordionSection title="Description and labels" openDefault >
+          <FlexContainer> 
+            <FormLabel htmlFor="options-title">Title</FormLabel>
+            <Input
+              type="text"
+              name="options-title"
+              value={title}
+              onChange={e => handleOnChange(e.target.value, "title")}
+              />
+            <FormLabel htmlFor="options-title">Caption</FormLabel>
+            <Input
+              type="text"
+              name="options-capton"
+              value={caption}
+              onChange={e => handleOnChange(e.target.value, "caption")}
+              />
+          </FlexContainer>
+        </AccordionSection>
+        <AccordionSection title="Filters">
+          Filters content
+        </AccordionSection>
+        <AccordionSection title="Orders">
+          Orders content
+        </AccordionSection>
+      </Accordion>      
     </FlexContainer>
+     
   );
 };
 


### PR DESCRIPTION
This PR adds accordion component to the widget-editor package

## Testing instructions
Run widget-editor application.
Test accordions. 1 accordion open by default. Set openDefault prop to accordion section to see other tabs by default.

## [Pivotal Tracker](https://www.pivotaltracker.com/n/projects/2154258/stories/171327330)