### PR TITLE
Filters + redux configuration

### DIFF
--- a/src/packages/core/src/constants.ts
+++ b/src/packages/core/src/constants.ts
@@ -1,5 +1,38 @@
 export const APP_NAMESPACE: string = "widgetEditor";
 
+export const ALLOWED_FIELD_TYPES = [
+  // --- NUMBER ----
+  { name: "esriFieldTypeSmallInteger", type: "number", provider: "esri" },
+  { name: "esriFieldTypeInteger", type: "number", provider: "esri" },
+  { name: "esriFieldTypeSingle", type: "number", provider: "esri" },
+  { name: "esriFieldTypeDouble", type: "number", provider: "esri" },
+  { name: "numeric", type: "number", provider: "psql" },
+  { name: "number", type: "number", provider: "carto" },
+  { name: "int", type: "number", provider: "psql" },
+  { name: "integer", type: "number", provider: "psql" },
+  { name: "float", type: "number", provider: "sql" },
+  { name: "long", type: "number", provider: "sql" },
+  { name: "double", type: "number", provider: "sql" },
+  { name: "real", type: "number", provider: "sql" },
+  { name: "decimal", type: "number", provider: "sql" },
+  // ----- TEXT -----
+  { name: "string", type: "string", provider: "sql" },
+  { name: "char", type: "string", provider: "sql" },
+  { name: "varchar", type: "string", provider: "sql" },
+  { name: "esriFieldTypeString", type: "string", provider: "esri" },
+  { name: "text", type: "string", provider: "elastic" },
+  // ----- DATE ----
+  { name: "esriFieldTypeDate", type: "date", provider: "esri" },
+  { name: "date", type: "date", provider: "sql" },
+  { name: "time", type: "date", provider: "sql" },
+  { name: "timestamp", type: "date", provider: "sql" },
+  { name: "interval", type: "date", provider: "sql" },
+  // ------ BOOLEAN -----
+  { name: "boolean", type: "boolean", provider: "sql" },
+  // ------ ARRAY -------
+  { name: "array", type: "array", provider: "sql" }
+];
+
 export const sagaEvents = {
   DATA_FLOW_DATASET_WIDGET_READY: `${APP_NAMESPACE}/SAGAS/DATA_FLOW/dataset_widget_ready`,
   DATA_FLOW_DATA_READY: `${APP_NAMESPACE}/SAGAS/DATA_FLOW/data_ready`,

--- a/src/packages/core/src/index.ts
+++ b/src/packages/core/src/index.ts
@@ -3,12 +3,14 @@ import Widget from "./services/widget";
 import Filters from "./services/filters";
 import Data from "./services/data";
 import Vega from "./services/vega";
+import Fields from "./services/fields";
 import StateProxy from "./services/state-proxy";
 import constants from "./constants";
 
 export { constants };
 export { Vega as VegaService };
 export { Data as DataService };
+export { Fields as FieldsService };
 export { StateProxy };
 export { Filters as FiltersService };
 export { Datasets as DatasetService };

--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -3,7 +3,7 @@ import { Dataset, Widget, Adapter, Generic } from "@packages/types";
 import FiltersService from "./filters";
 import VegaService from "./vega";
 
-import { sagaEvents } from "../constants";
+import { sagaEvents, ALLOWED_FIELD_TYPES } from "../constants";
 
 export default class DataService {
   adapter: Adapter.Service;
@@ -65,11 +65,36 @@ export default class DataService {
     this.dispatch({ type: sagaEvents.DATA_FLOW_WIDGET_DATA_READY });
   }
 
+  isFieldAllowed(field) {
+    const fieldTypeAllowed = ALLOWED_FIELD_TYPES.find(
+      val => val.name.toLowerCase() === field.type.toLowerCase()
+    );
+    const isCartodbId = field.columnName === "cartodb_id";
+    const result = !isCartodbId && fieldTypeAllowed;
+    return result;
+  }
+
   async getFieldsAndLayers() {
     const fields = await this.adapter.getFields();
     const layers = await this.adapter.getLayers();
 
-    this.setEditor({ layers, fields });
+    // Get field aliases from Dataset
+    const { columns } = this.dataset.attributes.metadata[0].attributes;
+    // Filter on allowed field types
+    const allowedFields = [];
+
+    Object.keys(fields).forEach(field => {
+      const f = {
+        ...fields[field],
+        columnName: field,
+        metadata: columns[field]
+      };
+      if (this.isFieldAllowed(f)) {
+        allowedFields.push(f);
+      }
+    });
+
+    this.setEditor({ layers, fields: allowedFields });
     this.dispatch({ type: sagaEvents.DATA_FLOW_DATA_READY });
   }
 

--- a/src/packages/core/src/services/fields.ts
+++ b/src/packages/core/src/services/fields.ts
@@ -1,0 +1,65 @@
+import { Config } from "@packages/types";
+
+export default class FieldsService {
+  configuration: Config.Payload;
+  datasetId: String;
+  fields: any;
+
+  NUMERIC_TYPE = "number";
+  COLUMN_TYPE = "string";
+
+  constructor(configuration: Config.Payload, datasetId: string, fields: any) {
+    this.configuration = configuration;
+    this.datasetId = datasetId;
+    this.fields = fields;
+  }
+
+  private query(q) {
+    return fetch(
+      `https://api.resourcewatch.org/v1/query/${this.datasetId}?${q}`
+    )
+      .then(response => {
+        if (response.status >= 400) throw new Error(response.statusText);
+        return response.json();
+      })
+      .then(jsonData => jsonData.data);
+  }
+
+  // TODO: Geostore
+  private getColumnMinAndMax(field: any) {
+    const { columnName } = field;
+    const tableName = this.configuration.value.tableName;
+    const query = `SELECT MIN(${columnName}) AS min, MAX(${columnName}) AS max FROM ${tableName}`;
+
+    return this.query(`sql=${query}`).then(data => (data ? data[0] : {}));
+  }
+
+  // TODO: Geostore
+  private getColumnValues(field, uniq = true) {
+    const { columnName } = field;
+    const tableName = this.configuration.value.tableName;
+
+    const uniqQueryPart = uniq ? `GROUP BY ${columnName}` : "";
+    const query = `SELECT ${columnName} FROM ${tableName} ${uniqQueryPart} ORDER BY ${columnName}`;
+
+    return this.query(`sql=${query}`).then(data =>
+      (data || []).map(d => d[columnName])
+    );
+  }
+
+  async getFieldInfo(field: any, column: string) {
+    const selectedField = this.fields.find(f => f.columnName === column);
+
+    if (selectedField.type === this.NUMERIC_TYPE) {
+      const res = await this.getColumnMinAndMax(selectedField);
+      return res;
+    }
+    console.log("selected field", selectedField);
+    if (selectedField.type === this.COLUMN_TYPE) {
+      const res = await this.getColumnValues(selectedField);
+      return res;
+    }
+
+    return "Hello world";
+  }
+}

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -4,14 +4,40 @@
 
 import { Filters, Config } from "@packages/types";
 
+import FieldsService from "./fields";
+
 import { sqlFields } from "../helpers/wiget-helper/constants";
+
+// constants
+const TYPE_COLUMNS = "columns";
+const TYPE_INDICATOR = "indicator";
+const TYPE_VALUE = "value";
+const TYPE_RANGE = "range";
+
+const DEFAULT_RANGE_FILTER = {
+  values: [0, 100],
+  type: TYPE_RANGE,
+  notNull: true,
+  max: 500,
+  min: 0
+};
+
+const DEFAULT_VALUE_FILTER = {
+  values: 0,
+  type: TYPE_VALUE,
+  notNull: true,
+  max: 500,
+  min: 0
+};
 
 export default class FiltersService implements Filters.Service {
   sql: string;
   datasetId: string;
   configuration: Config.Payload;
+
   constructor(data: any, datasetId: string) {
     this.configuration = data;
+
     this.sql = "";
 
     this.datasetId = datasetId;
@@ -35,7 +61,9 @@ export default class FiltersService implements Filters.Service {
     const { tableName: yTableName } = category;
 
     if (!xTableName && !yTableName) {
-      throw new Error('Filters service: canot parse table name from value nor category.');
+      throw new Error(
+        "Filters service: canot parse table name from value nor category."
+      );
     }
 
     // XXX: We prioritize xTableName, not sure if thats correct.
@@ -47,11 +75,15 @@ export default class FiltersService implements Filters.Service {
     const { name } = value;
 
     if (!aggregateFunction) {
-      this.sql = `${this.sql}, ${name} as ${sqlFields.category} FROM ${this.resolveTableName()}`;
+      this.sql = `${this.sql}, ${name} as ${
+        sqlFields.category
+      } FROM ${this.resolveTableName()}`;
     } else {
       const aggregation = aggregateFunction.toUpperCase();
       if (aggregation === "SUM" || aggregation === "COUNT") {
-        this.sql = `${this.sql}, ${aggregation}(${name}) as ${sqlFields.category} FROM ${this.resolveTableName()}`;
+        this.sql = `${this.sql}, ${aggregation}(${name}) as ${
+          sqlFields.category
+        } FROM ${this.resolveTableName()}`;
       } else {
         throw new Error(
           `Aggragate function (${aggregateFunction}) not implemented in filter service.`
@@ -62,11 +94,16 @@ export default class FiltersService implements Filters.Service {
 
   // Range conditions gets constructed as key => value AND key <= value
   // This is true if we have two values in our filter
-  private rangeCondition(condition: string, name: string, value: [number], type: string): string {
-     let range = condition;
-     value.forEach((v, index) => {
-      const serializeValue = type === 'date' ? `'${v}'` : v;
-      let statement = '';
+  private rangeCondition(
+    condition: string,
+    name: string,
+    value: [number],
+    type: string
+  ): string {
+    let range = condition;
+    value.forEach((v, index) => {
+      const serializeValue = type === "date" ? `'${v}'` : v;
+      let statement = "";
       if (index === 0) {
         statement = `${name} >= ${serializeValue}`;
       } else if (index === 1) {
@@ -79,7 +116,7 @@ export default class FiltersService implements Filters.Service {
 
   prepareFilters() {
     const { filters } = this.configuration;
-    let filtersQuery = 'WHERE';
+    let filtersQuery = "WHERE";
 
     if (filters && Array.isArray(filters) && filters.length > 0) {
       filters.forEach(({ name, value, type }) => {
@@ -91,7 +128,7 @@ export default class FiltersService implements Filters.Service {
             `Expected value range filter recived (${value.join()}), not yet implemented in filter service.`
           );
         }
-      })
+      });
     }
     this.sql = `${this.sql} ${filtersQuery}`;
   }
@@ -100,13 +137,12 @@ export default class FiltersService implements Filters.Service {
     const { groupBy, aggregateFunction } = this.configuration;
     if (groupBy) {
       const { name } = groupBy;
-      this.sql = `${this.sql} GROUP BY ${name || sqlFields.value}`; 
-    } else if (aggregateFunction && aggregateFunction !== 'none') {
+      this.sql = `${this.sql} GROUP BY ${name || sqlFields.value}`;
+    } else if (aggregateFunction && aggregateFunction !== "none") {
       // If there's an aggregate function, we group the results
       // with the first column (dimension x)
-      this.sql = `${this.sql} GROUP BY ${sqlFields.value}`; 
+      this.sql = `${this.sql} GROUP BY ${sqlFields.value}`;
     }
-
   }
 
   prepareOrderBy() {
@@ -132,7 +168,7 @@ export default class FiltersService implements Filters.Service {
 
   async requestWidgetData() {
     if (!this.datasetId) {
-      throw new Error('Error, datasetId not present in Filters service.');
+      throw new Error("Error, datasetId not present in Filters service.");
     }
 
     const response = await fetch(
@@ -140,5 +176,93 @@ export default class FiltersService implements Filters.Service {
     );
     const data = await response.json();
     return data;
+  }
+
+  // TODO: Cleanup
+  static async patchFilters(
+    filters,
+    payload,
+    configuration,
+    datasetId,
+    fields
+  ) {
+    const { values, id, type } = payload;
+    const fieldService = new FieldsService(configuration, datasetId, fields);
+
+    let patch = [];
+
+    async function asyncForEach(array, callback) {
+      for (let index = 0; index < array.length; index++) {
+        await callback(array[index], index, array);
+      }
+    }
+
+    if (type === TYPE_COLUMNS) {
+      await asyncForEach(filters, async filter => {
+        if (filter.id === id) {
+          const fieldInfo = await fieldService.getFieldInfo(
+            filter,
+            values.value
+          );
+          patch.push({
+            ...filter,
+            column: values.value,
+            dataType: values.dataType,
+            fieldInfo,
+            filter: {
+              ...filter.filter,
+              ...(filter.indicator === "range"
+                ? { values: [fieldInfo.min, fieldInfo.max] }
+                : {})
+            }
+          });
+        } else {
+          patch.push(filter);
+        }
+      });
+    }
+
+    if (type === TYPE_INDICATOR) {
+      // TODO: Check if value isset for current filter
+      // Then we need to assign that value when modifying filter
+      patch = filters.map(filter => {
+        if (filter.id === id) {
+          return {
+            ...filter,
+            indicator: values.value,
+            filter:
+              values.value === TYPE_RANGE
+                ? {
+                    ...DEFAULT_RANGE_FILTER,
+                    values: [filter.fieldInfo.min, filter.fieldInfo.max]
+                  }
+                : { ...DEFAULT_VALUE_FILTER, values: filter.fieldInfo.max }
+          };
+        }
+        return filter;
+      });
+    }
+
+    if (type === TYPE_RANGE) {
+      patch = filters.map(filter => {
+        if (filter.id === id) {
+          return { ...filter, filter: { ...filter.filter, values } };
+        }
+        return filter;
+      });
+    }
+
+    if (type === TYPE_VALUE) {
+      patch = filters.map(filter => {
+        if (filter.id === id) {
+          return { ...filter, filter: { ...filter.filter, values } };
+        }
+        return filter;
+      });
+    }
+
+    console.log("TYPE", patch);
+
+    return patch;
   }
 }

--- a/src/packages/widget-editor/package.json
+++ b/src/packages/widget-editor/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^16.12.0",
     "react-json-editor-ajrm": "^2.5.9",
     "react-redux": "^7.1.3",
+    "react-resize-detector": "^4.2.1",
     "react-select": "^3.0.8",
     "react-slider": "^1.0.2",
     "redux": "^4.0.4",

--- a/src/packages/widget-editor/src/components/accordion/component.js
+++ b/src/packages/widget-editor/src/components/accordion/component.js
@@ -1,74 +1,20 @@
-import React, { useState, useRef, useEffect } from "react";
-import styled, { css } from "styled-components";
+import React, { useState, useRef, useEffect } from 'react';
+import ReactResizeDetector from 'react-resize-detector';
 
-const StyledAccordion = styled.div`
-  width: 100%;
-  padding-top: 24px;
-  padding-bottom: 24px;
-`;
-
-const StyledAccordionContent = styled.div`
-  display: "block";
-  max-height: ${props => props.scrollHeight + "px" || "0"};
-  overflow-y: ${props => (props.scrollHeight ? "visible" : "hidden")};
-  transition: all 0.2s ease-out;
-  padding-left: 24px;
-  padding-top: ${props => (props.scrollHeight ? "18px" : "0" || "0")};
-  padding-bottom: ${props => (props.scrollHeight ? "18px" : "0" || "0")};
-`;
-
-const StyledAccordionButton = styled.a`
-  display: block;
-  height: 25px;
-  color: #393f44;
-  /* font-family: Lato;  */
-  font-size: 16px;
-  font-weight: bold;
-  line-height: 25px;
-  position: relative;
-  padding-left: 25px;
-  cursor: pointer;
-
-  &:before {
-    content: " ";
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: #c32d7b;
-    position: absolute;
-    left: 0;
-    top: 8px;
-  }
-`;
-
-const StyledAccordionSection = styled.div`
-  padding-top: 11px;
-  padding-bottom: 11px;
-  position: relative;
-
-  &:before {
-    content: " ";
-    height: 1px;
-    width: calc(100% - 24px);
-    display: block;
-    position: absolute;
-    top: 0;
-    background-color: #d2d3d6;
-    margin-left: 24px;
-  }
-
-  &:first-child {
-    &:before {
-      display: none;
-    }
-  }
-`;
+import {
+  StyledAccordionSection,
+  StyledAccordionContent,
+  StyledAccordionButton,
+  StyledAccordion
+} from './style';
 
 export const AccordionSection = ({ title, openDefault, children }) => {
   const contentRef = useRef({});
   const [outerHeight, setOuterHeight] = useState(0);
+  const [isOpen, setOpen] = useState(false);
 
   const clickToTitle = () => {
+    setOpen(!isOpen);
     const panel = contentRef.current;
     const height = outerHeight ? 0 : panel.scrollHeight;
     setOuterHeight(height);
@@ -76,27 +22,32 @@ export const AccordionSection = ({ title, openDefault, children }) => {
 
   const updateHeight = () => {
     const panel = contentRef.current;
-    const height = panel.scrollHeight;
-    setOuterHeight(height);
+    if (panel.scrollHeight > 0 && isOpen) {
+      const height = panel.scrollHeight;
+      setOuterHeight(height);
+    }
   }
 
   useEffect(() => {
-    console.log('init');
-    setTimeout(() => openDefault ? clickToTitle() : null, 0);   
+    setTimeout(() => openDefault ? clickToTitle() : null, 0);
   }, []);
-  
-  useEffect(() => {
-    console.log('scrollHeight');
-    if( outerHeight !== 0 ) updateHeight();   
-  }, [contentRef.current.scrollHeight]);
 
   return (
     <StyledAccordionSection>
       <StyledAccordionButton onClick={() => clickToTitle()}>
         {title}
       </StyledAccordionButton>
-      <StyledAccordionContent onChange={() => updateHeight() } ref={contentRef} scrollHeight={outerHeight}>
-        {children}
+      <StyledAccordionContent 
+        ref={contentRef}
+        scrollHeight={outerHeight}
+      >
+        <ReactResizeDetector 
+          handleHeight
+          skipOnMount
+          onResize={updateHeight}
+        >
+          {children}
+        </ReactResizeDetector>
       </StyledAccordionContent>
     </StyledAccordionSection>
   );

--- a/src/packages/widget-editor/src/components/accordion/component.js
+++ b/src/packages/widget-editor/src/components/accordion/component.js
@@ -45,6 +45,7 @@ const StyledAccordionSection = styled.div`
   padding-top: 11px;
   padding-bottom: 11px;
   position: relative;
+  overflow-y: hidden;
 
   &:before {
     content: " ";
@@ -75,8 +76,8 @@ export const AccordionSection = ({ title, openDefault, children }) => {
   };
 
   useEffect(() => {
-    if (openDefault) clickToTitle();
-  }, []);
+    setTimeout(() => openDefault ? clickToTitle() : null, 0);   
+  }, [children]);
 
   return (
     <StyledAccordionSection>

--- a/src/packages/widget-editor/src/components/accordion/component.js
+++ b/src/packages/widget-editor/src/components/accordion/component.js
@@ -45,7 +45,6 @@ const StyledAccordionSection = styled.div`
   padding-top: 11px;
   padding-bottom: 11px;
   position: relative;
-  overflow-y: hidden;
 
   &:before {
     content: " ";
@@ -66,7 +65,7 @@ const StyledAccordionSection = styled.div`
 `;
 
 export const AccordionSection = ({ title, openDefault, children }) => {
-  const contentRef = useRef(null);
+  const contentRef = useRef({});
   const [outerHeight, setOuterHeight] = useState(0);
 
   const clickToTitle = () => {
@@ -75,16 +74,28 @@ export const AccordionSection = ({ title, openDefault, children }) => {
     setOuterHeight(height);
   };
 
+  const updateHeight = () => {
+    const panel = contentRef.current;
+    const height = panel.scrollHeight;
+    setOuterHeight(height);
+  }
+
   useEffect(() => {
+    console.log('init');
     setTimeout(() => openDefault ? clickToTitle() : null, 0);   
-  }, [children]);
+  }, []);
+  
+  useEffect(() => {
+    console.log('scrollHeight');
+    if( outerHeight !== 0 ) updateHeight();   
+  }, [contentRef.current.scrollHeight]);
 
   return (
     <StyledAccordionSection>
       <StyledAccordionButton onClick={() => clickToTitle()}>
         {title}
       </StyledAccordionButton>
-      <StyledAccordionContent ref={contentRef} scrollHeight={outerHeight}>
+      <StyledAccordionContent onChange={() => updateHeight() } ref={contentRef} scrollHeight={outerHeight}>
         {children}
       </StyledAccordionContent>
     </StyledAccordionSection>

--- a/src/packages/widget-editor/src/components/accordion/style.js
+++ b/src/packages/widget-editor/src/components/accordion/style.js
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+
+export const StyledAccordion = styled.div`
+  width: 100%;
+  padding-top: 24px;
+  padding-bottom: 24px;
+`;
+
+export const StyledAccordionContent = styled.div`
+  display: "block";
+  max-height: ${props => props.scrollHeight + "px" || "0"};
+  overflow-y: ${props => (props.scrollHeight ? "visible" : "hidden")};
+  transition: all 0.2s ease-out;
+  padding-left: 24px;
+  padding-top: ${props => (props.scrollHeight ? "18px" : "0" || "0")};
+  padding-bottom: ${props => (props.scrollHeight ? "18px" : "0" || "0")};
+`;
+
+export const StyledAccordionButton = styled.a`
+  display: block;
+  height: 25px;
+  color: #393f44;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 25px;
+  position: relative;
+  padding-left: 25px;
+  cursor: pointer;
+
+&:before {
+  content: " ";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #c32d7b;
+  position: absolute;
+  left: 0;
+  top: 8px;
+}
+`;
+
+export const StyledAccordionSection = styled.div`
+  padding-top: 11px;
+  padding-bottom: 11px;
+  position: relative;
+
+&:before {
+  content: " ";
+  height: 1px;
+  width: calc(100% - 24px);
+  display: block;
+  position: absolute;
+  top: 0;
+  background-color: #d2d3d6;
+  margin-left: 24px;
+}
+
+&:first-child {
+  &:before {
+    display: none;
+  }
+}
+`;

--- a/src/packages/widget-editor/src/components/button/component.js
+++ b/src/packages/widget-editor/src/components/button/component.js
@@ -12,6 +12,13 @@ const StyledButton = styled.button`
   outline: 1;
 
   ${props =>
+    props.size &&
+    props.size === "small" &&
+    css`
+      padding: 7px 15px;
+    `}
+
+  ${props =>
     props.type &&
     props.type === "cta" &&
     css`

--- a/src/packages/widget-editor/src/components/editor-options/component.js
+++ b/src/packages/widget-editor/src/components/editor-options/component.js
@@ -1,9 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import styled from "styled-components";
 import { Accordion, AccordionSection } from "components/accordion";
 import { Tabs, Tab } from "components/tabs";
-
-import QueryLimit from "components/query-limit";
 import WidgetInfo from "components/widget-info";
 import OrderValues from "components/order-values";
 import TableView from "components/table-view";
@@ -23,41 +21,16 @@ const StyledContainer = styled.div`
 `;
 
 const EditorOptions = ({ orderBy }) => {
-
-  const [minValue, setMinValue] = useState(10);
-  const [maxValue, setMaxValue] = useState(40);
-  const onSetData = (value) => {
-    if (Array.isArray(value)) {
-      setMinValue(Number(value[0])); 
-      setMaxValue(Number(value[1]));
-    } else {
-      setMaxValue(Number(value));
-    }
-  }
-
   return (
     <StyledContainer>
       <Tabs>
         <Tab label="General">
           <Accordion>
-            <AccordionSection title="Description and labels">
+            <AccordionSection title="Description and labels" openDefault>
               <WidgetInfo />
             </AccordionSection>
-            <AccordionSection title="Filters" openDefault>
-
+            <AccordionSection title="Filters">
               <Filter />
-
-              {/* <QueryLimit 
-                max={100}
-                label="Limit"
-                value={[minValue, maxValue]}
-                onChange={(value) => onSetData(value)}
-                handleOnChangeValue={(value, key = 'maxValue') =>
-                  key === 'minValue'
-                  ? setMinValue(Number(value))
-                  : setMaxValue(Number(value))
-                }
-              /> */}
             </AccordionSection>
             <AccordionSection title="Order">
               {orderBy && <OrderValues />}

--- a/src/packages/widget-editor/src/components/editor-options/component.js
+++ b/src/packages/widget-editor/src/components/editor-options/component.js
@@ -47,7 +47,7 @@ const EditorOptions = ({ orderBy }) => {
 
               <Filter />
 
-              <QueryLimit 
+              {/* <QueryLimit 
                 max={100}
                 label="Limit"
                 value={[minValue, maxValue]}
@@ -57,7 +57,7 @@ const EditorOptions = ({ orderBy }) => {
                   ? setMinValue(Number(value))
                   : setMaxValue(Number(value))
                 }
-              />
+              /> */}
             </AccordionSection>
             <AccordionSection title="Order">
               {orderBy && <OrderValues />}

--- a/src/packages/widget-editor/src/components/editor-options/component.js
+++ b/src/packages/widget-editor/src/components/editor-options/component.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { Accordion, AccordionSection } from "components/accordion";
 import { Tabs, Tab } from "components/tabs";
@@ -8,6 +8,7 @@ import WidgetInfo from "components/widget-info";
 import OrderValues from "components/order-values";
 import TableView from "components/table-view";
 import JsonEditor from "components/json-editor";
+import Filter from "components/filter";
 
 import { FOOTER_HEIGHT, DEFAULT_BORDER } from "style-constants";
 
@@ -43,6 +44,9 @@ const EditorOptions = ({ orderBy }) => {
               <WidgetInfo />
             </AccordionSection>
             <AccordionSection title="Filters" openDefault>
+
+              <Filter />
+
               <QueryLimit 
                 max={100}
                 label="Limit"

--- a/src/packages/widget-editor/src/components/filter/component.js
+++ b/src/packages/widget-editor/src/components/filter/component.js
@@ -1,9 +1,8 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React from 'react';
+import FormLabel from 'styles-common/form-label';
+import InputGroup from 'styles-common/input-group';
 import Button from 'components/button';
-import FormLabel from "styles-common/form-label";
-import InputGroup from "styles-common/input-group";
 import {
-  DEFAULT_FILTERS,
   DEFAULT_RANGE_FILTER,
   DEFAULT_VALUE_FILTER,
   DEFAULT_COLUMNS_FILTER,
@@ -14,27 +13,15 @@ import {
 import FilterRange from './components/FilterRange';
 import FilterValue from './components/FilterValue';
 import FilterColumn from './components/FilterColumn';
+import AddSection from './components/AddSection';
 import {
   StyledFilterBox,
-  StyledAddSection,
-  StyledAddModal,
-  StyledIcons,
-  StyledIconBox,
   StyledEmpty,
-  StyledFilterSection
+  StyledFilterSection,
+  StyledDeleteBox
 } from './style';
 
 const Filter = ({ patchConfiguration, filters = [], fields = [] }) => {
-
-
-  const [isAddModal, openAddModal] = useState(false);
-  const ref = useRef(null);
-
-  const handleClickOutside = (event) => {
-    if (ref.current && !ref.current.contains(event.target)) {
-      openAddModal(false);
-    }
-  }
 
   const optionData = Object.keys(fields).map(field => {
     return {
@@ -54,59 +41,38 @@ const Filter = ({ patchConfiguration, filters = [], fields = [] }) => {
   }
 
   const addFilter = (filter = TYPE_RANGE) => {
-    let filterData;
-    if (filter === TYPE_RANGE) {
-      filterData = DEFAULT_RANGE_FILTER;
-    } else if (filter === TYPE_VALUE) {
-      filterData = DEFAULT_VALUE_FILTER;
-    } else if (filter === TYPE_COLUMNS) {
-      filterData = DEFAULT_COLUMNS_FILTER;
+    const isFilter = filters.find(f => f.type === filter);
+    if (!isFilter) {
+      let filterData;
+      if (filter === TYPE_RANGE) {
+        filterData = DEFAULT_RANGE_FILTER;
+      } else if (filter === TYPE_VALUE) {
+        filterData = DEFAULT_VALUE_FILTER;
+      } else if (filter === TYPE_COLUMNS) {
+        filterData = DEFAULT_COLUMNS_FILTER;
+      }
+      patchConfiguration({
+        filters: [...filters, filterData]
+      });
     }
-    patchConfiguration({
-      filters: [...filters, filterData]
-    });
-    openAddModal(false);
   }
 
-  useEffect(() => {
-    document.addEventListener('click', handleClickOutside, true);
-    return () => {
-        document.removeEventListener('click', handleClickOutside, true);
-    };
-  });
+  const removeFilter = (filter = TYPE_RANGE) => {
+    const newFilters = filters.filter(f => f.type !== filter) || [];
+    patchConfiguration({
+      filters: newFilters
+    });
+  }
 
   return (
     <StyledFilterBox>
-      <StyledAddSection>
-        <Button
-          size="small"
-          onClick={() => openAddModal(!isAddModal)}
-        >
-          Add Filter
-        </Button>
-        {isAddModal && (
-          <StyledAddModal ref={ref}>
-            <StyledIcons>
-              <StyledIconBox>
-                <Button onClick={() => addFilter(TYPE_RANGE)}>
-                  Range
-                </Button>
-              </StyledIconBox>
-              <StyledIconBox>
-                <Button onClick={() => addFilter(TYPE_VALUE)}>
-                  Value
-                </Button>
-              </StyledIconBox>
-              <StyledIconBox>
-                <Button onClick={() => addFilter(TYPE_COLUMNS)}>
-                  Select
-                </Button>
-              </StyledIconBox>
-            </StyledIcons>
-          </StyledAddModal>  
-        )}
-      </StyledAddSection>
-
+      
+      <AddSection
+        addFilter={addFilter}
+        removeFilter={removeFilter}
+        filters={filters}
+      />
+      
       {!filters.length && (
         <StyledEmpty>
           No filters found. Please, add them.
@@ -117,6 +83,12 @@ const Filter = ({ patchConfiguration, filters = [], fields = [] }) => {
         <StyledFilterSection key={filterId}>
           <InputGroup>
             <FormLabel htmlFor="options-title">{filter.indicator}</FormLabel>
+            <StyledDeleteBox>
+              <Button type="highlight" onClick={() => removeFilter(filter.type)}>
+                Delete
+              </Button>
+            </StyledDeleteBox> 
+
             {filter.type === TYPE_RANGE && (
               <FilterRange 
                 id={filterId} 

--- a/src/packages/widget-editor/src/components/filter/component.js
+++ b/src/packages/widget-editor/src/components/filter/component.js
@@ -1,0 +1,86 @@
+import React, { useEffect } from 'react';
+import { DEFAULT_FILTERS, TYPE_RANGE, TYPE_COLUMNS, TYPE_VALUE } from './const';
+import FilterRange from './components/FilterRange';
+import FilterValue from './components/FilterValue';
+import { StyledFilterBox } from './style';
+
+import Select from "react-select";
+
+const InputStyles = {
+  control: () => ({
+    // none of react-select's styles are passed to <Control />
+    display: "flex",
+    border: "1px solid rgba(202,204,208,0.85)",
+    borderRadius: "4px",
+    padding: "3px 0"
+  }),
+  option: base => ({
+    ...base
+  })
+};
+
+const ORDER_OPTIONS = [
+  { label: "Ascending", value: "asc" },
+  { label: "Descending", value: "desc" }
+];
+
+const Filter = ({ patchConfiguration, filters = [], fields = [] }) => {
+
+  const optionData = Object.keys(fields).map(field => {
+    return {
+      label: field.replace(/_/gi,' '),
+      value: field,
+    };
+  })
+
+  const setData = (values, id) => {
+    const allFilters = [...filters];
+    const filterData = allFilters[id];
+    filterData['values'] = values;
+    allFilters[id] = filterData;
+    patchConfiguration({
+      filters: allFilters
+    })
+  }
+
+  useEffect(()=>{
+    patchConfiguration({
+      filters: DEFAULT_FILTERS
+    })
+  },[]);
+
+  return (
+    <StyledFilterBox>
+      {filters.map((filter, filterId) => {
+
+        return (
+          <div key={filterId}>
+            {filter.type === TYPE_RANGE && (
+              <FilterRange 
+                id={filterId} 
+                filter={filter}
+                setData={setData} 
+              />
+            )}
+
+            {filter.type === TYPE_VALUE && (
+              <FilterValue 
+                id={filterId} 
+                filter={filter}
+                setData={setData} 
+              />
+            )}
+
+            {filter.type === TYPE_COLUMNS && (
+              <Select 
+                options={optionData}
+              />
+            )}
+          </div>
+        );
+      })}
+    </StyledFilterBox>
+  );
+}
+
+export default Filter;

--- a/src/packages/widget-editor/src/components/filter/component.js
+++ b/src/packages/widget-editor/src/components/filter/component.js
@@ -1,123 +1,134 @@
-import React from 'react';
-import FormLabel from 'styles-common/form-label';
-import InputGroup from 'styles-common/input-group';
-import Button from 'components/button';
+import React from "react";
+
+import { FiltersService } from "@packages/core";
+
+import InputGroup from "styles-common/input-group";
+import Button from "components/button";
+import uniqueId from "lodash/uniqueId";
+
+// FieldsService
+
 import {
   DEFAULT_RANGE_FILTER,
   DEFAULT_VALUE_FILTER,
-  DEFAULT_COLUMNS_FILTER,
   TYPE_RANGE,
   TYPE_COLUMNS,
-  TYPE_VALUE
-} from './const';
-import FilterRange from './components/FilterRange';
-import FilterValue from './components/FilterValue';
-import FilterColumn from './components/FilterColumn';
-import AddSection from './components/AddSection';
+  TYPE_INDICATOR,
+  TYPE_VALUE,
+  COLUMN_FILTER_GROUP,
+  FILTER_TYPES
+} from "./const";
+
+import FilterRange from "./components/FilterRange";
+import FilterValue from "./components/FilterValue";
+import FilterColumn from "./components/FilterColumn";
+import FilterIndicator from "./components/FilterIndicator";
+import AddSection from "./components/AddSection";
+
 import {
   StyledFilterBox,
   StyledEmpty,
   StyledFilterSection,
+  StyledFilter,
   StyledDeleteBox
-} from './style';
+} from "./style";
 
-const Filter = ({ patchConfiguration, filters = [], fields = [] }) => {
-
-  const optionData = Object.keys(fields).map(field => {
+const Filter = ({
+  setFilters,
+  filters = [],
+  fields = [],
+  configuration,
+  datasetId
+}) => {
+  const availableColumns = fields.map(field => {
     return {
-      label: field.replace(/_/gi,' '),
-      value: field,
+      label:
+        field.metadata && field.metadata.alias
+          ? field.metadata.alias
+          : field.columnName.replace(/_/gi, " "),
+      value: field.columnName,
+      dataType: field.type
     };
-  })
+  });
 
-  const setData = (values, id) => {
-    const allFilters = [...filters];
-    const filterData = allFilters[id];
-    filterData['values'] = values;
-    allFilters[id] = filterData;
-    patchConfiguration({
-      filters: allFilters
-    })
-  }
+  const setData = async (values, id, type) => {
+    const patch = await FiltersService.patchFilters(
+      filters,
+      { values, id, type },
+      configuration,
+      datasetId,
+      fields
+    );
 
-  const addFilter = (filter = TYPE_RANGE) => {
-    const isFilter = filters.find(f => f.type === filter);
-    if (!isFilter) {
-      let filterData;
-      if (filter === TYPE_RANGE) {
-        filterData = DEFAULT_RANGE_FILTER;
-      } else if (filter === TYPE_VALUE) {
-        filterData = DEFAULT_VALUE_FILTER;
-      } else if (filter === TYPE_COLUMNS) {
-        filterData = DEFAULT_COLUMNS_FILTER;
-      }
-      patchConfiguration({
-        filters: [...filters, filterData]
-      });
-    }
-  }
-
-  const removeFilter = (filter = TYPE_RANGE) => {
-    const newFilters = filters.filter(f => f.type !== filter) || [];
-    patchConfiguration({
-      filters: newFilters
+    setFilters({
+      list: patch
     });
-  }
+  };
+
+  const addFilter = () => {
+    setFilters({
+      list: [...filters, { ...COLUMN_FILTER_GROUP, id: uniqueId("we-filter-") }]
+    });
+  };
+
+  const removeFilter = id => {
+    const newFilters = filters.filter(f => f.id !== id) || [];
+    setFilters({
+      list: newFilters
+    });
+  };
 
   return (
     <StyledFilterBox>
-      
-      <AddSection
-        addFilter={addFilter}
-        removeFilter={removeFilter}
-        filters={filters}
-      />
-      
+      <AddSection addFilter={addFilter} />
       {!filters.length && (
-        <StyledEmpty>
-          No filters found. Please, add them.
-        </StyledEmpty>
+        <StyledEmpty>No filters found. Please, add them.</StyledEmpty>
       )}
 
-      {filters.map((filter, filterId) => (
-        <StyledFilterSection key={filterId}>
-          <InputGroup>
-            <FormLabel htmlFor="options-title">{filter.indicator}</FormLabel>
+      {filters.map(filter => (
+        <StyledFilterSection key={filter.id}>
+          <InputGroup noMargins={true}>
+            <FilterColumn
+              filter={filter}
+              setData={setData}
+              optionData={availableColumns}
+            />
             <StyledDeleteBox>
-              <Button type="highlight" onClick={() => removeFilter(filter.type)}>
+              <Button type="highlight" onClick={() => removeFilter(filter.id)}>
                 Delete
               </Button>
-            </StyledDeleteBox> 
-
-            {filter.type === TYPE_RANGE && (
-              <FilterRange 
-                id={filterId} 
+            </StyledDeleteBox>
+          </InputGroup>
+          <StyledFilter>
+            <InputGroup noMargins={true}>
+              <FilterIndicator
                 filter={filter}
-                setData={setData} 
+                disabled={filter.column === null}
+                setData={setData}
+                optionData={FILTER_TYPES}
               />
-            )}
+            </InputGroup>
 
-            {filter.type === TYPE_VALUE && (
-              <FilterValue 
-                id={filterId} 
-                filter={filter}
-                setData={setData} 
-              />
-            )}
-
-            {filter.type === TYPE_COLUMNS && (
-              <FilterColumn 
-                id={filterId}
+            {filter.indicator === TYPE_RANGE && (
+              <FilterRange
+                disabled={filter.column === null}
                 filter={filter}
                 setData={setData}
-                optionData={optionData}
               />
             )}
-          </InputGroup>
+
+            {filter.indicator === TYPE_VALUE && (
+              <FilterValue
+                disabled={filter.column === null}
+                filter={filter}
+                setData={setData}
+              />
+            )}
+          </StyledFilter>
         </StyledFilterSection>
       ))}
     </StyledFilterBox>
   );
-}
+};
 
 export default Filter;

--- a/src/packages/widget-editor/src/components/filter/components/AddSection/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/AddSection/component.js
@@ -1,0 +1,80 @@
+import React, { useState, useRef, useEffect } from 'react';
+import Button from 'components/button';
+import {
+  StyledAddSection,
+  StyledAddModal,
+  StyledIcons,
+  StyledIconBox,
+} from './style';
+import {
+  TYPE_RANGE,
+  TYPE_COLUMNS,
+  TYPE_VALUE
+} from '../../const';
+
+
+const AddSection = ({ addFilter, removeFilter, filters }) => {
+
+  const [isAddModal, openAddModal] = useState(false);
+  const refModal = useRef(null);
+  const refButton = useRef(null);
+  const activeFilters = filters ? filters.map(f => f.type) : [];
+  const isDisabled = type => activeFilters.indexOf(type) !== -1;
+  const handleClickOutside = event =>
+    refModal.current
+    && refButton.current
+    && !refModal.current.contains(event.target)
+    && !refButton.current.contains(event.target)
+    ? openAddModal(false)
+    : null;
+
+  const handleAdd = type => {
+    openAddModal(false);
+    addFilter(type)
+  }
+
+  console.log(refButton);
+
+  useEffect(() => {
+    document.addEventListener('click', handleClickOutside, true);
+    return () => {
+        document.removeEventListener('click', handleClickOutside, true);
+    };
+  });
+
+
+  return (
+    <StyledAddSection>
+      <div ref={refButton}>
+        <Button
+          size="small"
+          onClick={() => openAddModal(!isAddModal)}
+        >
+          Add Filter
+        </Button>
+      </div>
+      {isAddModal && (
+        <StyledAddModal ref={refModal}>
+          <StyledIcons>
+            <StyledIconBox disabled={isDisabled(TYPE_RANGE)}>
+              <Button onClick={() => handleAdd(TYPE_RANGE)}>
+                Range
+              </Button>
+            </StyledIconBox>
+            <StyledIconBox disabled={isDisabled(TYPE_VALUE)}>
+              <Button onClick={() => handleAdd(TYPE_VALUE)}>
+                Value
+              </Button>
+            </StyledIconBox>
+            <StyledIconBox disabled={isDisabled(TYPE_COLUMNS)}>
+              <Button onClick={() => handleAdd(TYPE_COLUMNS)}>
+                Select
+              </Button>
+            </StyledIconBox>
+          </StyledIcons>
+        </StyledAddModal>  
+      )}
+    </StyledAddSection>
+  )
+}
+export default AddSection;

--- a/src/packages/widget-editor/src/components/filter/components/AddSection/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/AddSection/component.js
@@ -33,8 +33,6 @@ const AddSection = ({ addFilter, removeFilter, filters }) => {
     addFilter(type)
   }
 
-  console.log(refButton);
-
   useEffect(() => {
     document.addEventListener('click', handleClickOutside, true);
     return () => {

--- a/src/packages/widget-editor/src/components/filter/components/AddSection/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/AddSection/component.js
@@ -1,78 +1,15 @@
-import React, { useState, useRef, useEffect } from 'react';
-import Button from 'components/button';
-import {
-  StyledAddSection,
-  StyledAddModal,
-  StyledIcons,
-  StyledIconBox,
-} from './style';
-import {
-  TYPE_RANGE,
-  TYPE_COLUMNS,
-  TYPE_VALUE
-} from '../../const';
+import React, { useState, useRef, useEffect } from "react";
+import Button from "components/button";
 
+import { StyledAddSection } from "./style";
 
-const AddSection = ({ addFilter, removeFilter, filters }) => {
-
-  const [isAddModal, openAddModal] = useState(false);
-  const refModal = useRef(null);
-  const refButton = useRef(null);
-  const activeFilters = filters ? filters.map(f => f.type) : [];
-  const isDisabled = type => activeFilters.indexOf(type) !== -1;
-  const handleClickOutside = event =>
-    refModal.current
-    && refButton.current
-    && !refModal.current.contains(event.target)
-    && !refButton.current.contains(event.target)
-    ? openAddModal(false)
-    : null;
-
-  const handleAdd = type => {
-    openAddModal(false);
-    addFilter(type)
-  }
-
-  useEffect(() => {
-    document.addEventListener('click', handleClickOutside, true);
-    return () => {
-        document.removeEventListener('click', handleClickOutside, true);
-    };
-  });
-
-
+const AddSection = ({ addFilter }) => {
   return (
     <StyledAddSection>
-      <div ref={refButton}>
-        <Button
-          size="small"
-          onClick={() => openAddModal(!isAddModal)}
-        >
-          Add Filter
-        </Button>
-      </div>
-      {isAddModal && (
-        <StyledAddModal ref={refModal}>
-          <StyledIcons>
-            <StyledIconBox disabled={isDisabled(TYPE_RANGE)}>
-              <Button onClick={() => handleAdd(TYPE_RANGE)}>
-                Range
-              </Button>
-            </StyledIconBox>
-            <StyledIconBox disabled={isDisabled(TYPE_VALUE)}>
-              <Button onClick={() => handleAdd(TYPE_VALUE)}>
-                Value
-              </Button>
-            </StyledIconBox>
-            <StyledIconBox disabled={isDisabled(TYPE_COLUMNS)}>
-              <Button onClick={() => handleAdd(TYPE_COLUMNS)}>
-                Select
-              </Button>
-            </StyledIconBox>
-          </StyledIcons>
-        </StyledAddModal>  
-      )}
+      <Button size="small" onClick={() => addFilter()}>
+        Add Filter
+      </Button>
     </StyledAddSection>
-  )
-}
+  );
+};
 export default AddSection;

--- a/src/packages/widget-editor/src/components/filter/components/AddSection/index.js
+++ b/src/packages/widget-editor/src/components/filter/components/AddSection/index.js
@@ -1,0 +1,3 @@
+import AddSection from './component';
+
+export default AddSection;

--- a/src/packages/widget-editor/src/components/filter/components/AddSection/style.js
+++ b/src/packages/widget-editor/src/components/filter/components/AddSection/style.js
@@ -1,47 +1,7 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 export const StyledAddSection = styled.div`
   position: absolute;
-  top:-40px;
+  top: -40px;
   right: 0;
 `;
-
-export const StyledAddModal = styled.div`
-  position: absolute;
-  top: 40px;
-  right: 0;
-  width: 300px;
-  height: 100px;
-  background-color: white;
-  z-index: 3;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.09);
-  border-color: rgba(26,28,34,0.1);
-  border-style: solid;
-  border-width: 1px 1px 1px 1px;
-`;
-
-export const StyledIcons = styled.div`
-  display: flex;
-  align-items: stretch;
-  justify-content: flex-start;
-  height: 100%;
-  padding: 10px;
-`;
-
-export const StyledIconBox = styled.div`
-  width: 33.333%;
-  border-radius: 10px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  cursor: pointer;
-  padding-left: 10px;
-  padding-right: 10px;
-  opacity: ${props => props.disabled ? 0.3 : 1};
-  pointer-events: ${props => props.disabled ? 'none' : 'auto'};
-  button {
-    height:100%;
-  }
-`;
-

--- a/src/packages/widget-editor/src/components/filter/components/AddSection/style.js
+++ b/src/packages/widget-editor/src/components/filter/components/AddSection/style.js
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+
+export const StyledAddSection = styled.div`
+  position: absolute;
+  top:-40px;
+  right: 0;
+`;
+
+export const StyledAddModal = styled.div`
+  position: absolute;
+  top: 40px;
+  right: 0;
+  width: 300px;
+  height: 100px;
+  background-color: white;
+  z-index: 3;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.09);
+  border-color: rgba(26,28,34,0.1);
+  border-style: solid;
+  border-width: 1px 1px 1px 1px;
+`;
+
+export const StyledIcons = styled.div`
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-start;
+  height: 100%;
+  padding: 10px;
+`;
+
+export const StyledIconBox = styled.div`
+  width: 33.333%;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  cursor: pointer;
+  padding-left: 10px;
+  padding-right: 10px;
+  opacity: ${props => props.disabled ? 0.3 : 1};
+  pointer-events: ${props => props.disabled ? 'none' : 'auto'};
+  button {
+    height:100%;
+  }
+`;
+

--- a/src/packages/widget-editor/src/components/filter/components/FilterColumn/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterColumn/component.js
@@ -1,22 +1,23 @@
-import React from 'react';
+import React from "react";
 import Select from "react-select";
 
-const FilterColumn = ({ filter, setData = () => {}, id, optionData = [] }) => {
+import { TYPE_COLUMNS } from "components/filter/const";
 
-  const { values } = filter;
-
+const FilterColumn = ({ filter, setData = () => {}, optionData = [] }) => {
   const handleChange = options => {
-    setData(options, id);
+    setData(options, filter.id, TYPE_COLUMNS);
   };
 
+  const value = optionData.find(({ value }) => value === filter.column);
+
   return (
-    <Select 
-      value={values}
-      name={`filter-column-${id}`}
-      isMulti
+    <Select
+      value={value}
+      placeholder="Select Column"
+      name={`filter-column-${filter.id}`}
       options={optionData}
       onChange={handleChange}
     />
-  ); 
-}
+  );
+};
 export default FilterColumn;

--- a/src/packages/widget-editor/src/components/filter/components/FilterColumn/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterColumn/component.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import Select from "react-select";
+
+const FilterColumn = ({ filter, setData = () => {}, id, optionData = [] }) => {
+
+  const { values } = filter;
+
+  const handleChange = options => {
+    setData(options, id);
+  };
+
+  return (
+    <Select 
+      value={values}
+      name={`filter-column-${id}`}
+      isMulti
+      options={optionData}
+      onChange={handleChange}
+    />
+  ); 
+}
+export default FilterColumn;

--- a/src/packages/widget-editor/src/components/filter/components/FilterColumn/index.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterColumn/index.js
@@ -1,0 +1,3 @@
+import FilterColumn from './component';
+
+export default FilterColumn;

--- a/src/packages/widget-editor/src/components/filter/components/FilterColumn/index.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterColumn/index.js
@@ -1,3 +1,3 @@
-import FilterColumn from './component';
+import FilterColumn from "./component";
 
 export default FilterColumn;

--- a/src/packages/widget-editor/src/components/filter/components/FilterIndicator/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterIndicator/component.js
@@ -1,0 +1,31 @@
+import React from "react";
+import Select from "react-select";
+
+import { TYPE_INDICATOR } from "components/filter/const";
+
+const FilterIndicator = ({
+  filter,
+  disabled = false,
+  setData = () => {},
+  optionData = []
+}) => {
+  const handleChange = options => {
+    setData(options, filter.id, TYPE_INDICATOR);
+  };
+
+  return (
+    <Select
+      isDisabled={disabled}
+      value={
+        filter.indicator
+          ? optionData.find(o => o.value === filter.indicator)
+          : null
+      }
+      placeholder="Select Indicator"
+      name={`filter-indicator-${filter.id}`}
+      options={optionData}
+      onChange={handleChange}
+    />
+  );
+};
+export default FilterIndicator;

--- a/src/packages/widget-editor/src/components/filter/components/FilterIndicator/index.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterIndicator/index.js
@@ -1,0 +1,3 @@
+import FilterIndicator from "./component";
+
+export default FilterIndicator;

--- a/src/packages/widget-editor/src/components/filter/components/FilterRange/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterRange/component.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import QueryLimit from "components/query-limit";
+
+const FilterRange = ({ filter, setData, id }) => {
+
+  const { values } = filter;
+  const [minValue, maxValue] = values;
+
+  const onSetData = (values) => {
+    setData(values, id);
+  }
+
+  const handleOnChangeValue = (value, key = 'maxValue') => {
+    const newValues = key === 'maxValue' ? [minValue, Number(value)] : [Number(value), maxValue];
+    setData(newValues, id);
+  }
+  
+
+  return (
+    <QueryLimit 
+      max={100}
+      label="Limit"
+      value={[minValue, maxValue]}
+      onChange={(value) => onSetData(value)}
+      handleOnChangeValue={handleOnChangeValue}
+    />
+  ); 
+}
+
+export default FilterRange;

--- a/src/packages/widget-editor/src/components/filter/components/FilterRange/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterRange/component.js
@@ -1,30 +1,37 @@
-import React from 'react';
+import React from "react";
 import QueryLimit from "components/query-limit";
 
-const FilterRange = ({ filter, setData, id }) => {
+import { TYPE_RANGE } from "components/filter/const";
 
-  const { values } = filter;
+const FilterRange = ({ filter, disabled = false, setData }) => {
+  const { values } = filter.filter;
+  const { min, max } = filter.fieldInfo
+    ? filter.fieldInfo
+    : { min: 0, max: 100 };
   const [minValue, maxValue] = values;
 
-  const onSetData = (values) => {
-    setData(values, id);
-  }
+  const onSetData = values => {
+    setData(values, filter.id, TYPE_RANGE);
+  };
 
-  const handleOnChangeValue = (value, key = 'maxValue') => {
-    const newValues = key === 'maxValue' ? [minValue, Number(value)] : [Number(value), maxValue];
+  const handleOnChangeValue = (value, key = "maxValue") => {
+    const newValues =
+      key === "maxValue"
+        ? [minValue, Number(value)]
+        : [Number(value), maxValue];
     setData(newValues, id);
-  }
-  
+  };
 
   return (
-    <QueryLimit 
-      max={100}
-      label="Limit"
+    <QueryLimit
+      max={max}
+      min={min}
+      disabled={disabled}
       value={[minValue, maxValue]}
-      onChange={(value) => onSetData(value)}
+      onChange={value => onSetData(value)}
       handleOnChangeValue={handleOnChangeValue}
     />
-  ); 
-}
+  );
+};
 
 export default FilterRange;

--- a/src/packages/widget-editor/src/components/filter/components/FilterRange/index.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterRange/index.js
@@ -1,0 +1,3 @@
+import FilterRange from './component';
+
+export default FilterRange;

--- a/src/packages/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -1,25 +1,35 @@
-import React from 'react';
-import Input from 'styles-common/input';
-import styled from 'styled-components';
+import React from "react";
+import Input from "styles-common/input";
+import styled from "styled-components";
+
+import isFloat from "helpers/isFloat";
+
+import { TYPE_VALUE } from "components/filter/const";
 
 const StyledInput = styled(Input)`
   text-align: left !important;
 `;
 
-const FilterValue = ({ filter, setData, id }) => {
+const FilterValue = ({ filter, disabled = false, setData }) => {
+  const { values } = filter.filter;
+  const { min, max } = filter.fieldInfo
+    ? filter.fieldInfo
+    : { min: 0, max: 100 };
 
-  const { values, min, max } = filter;
+  const isFloatingPoint = isFloat(min) || isFloat(max);
 
   return (
     <StyledInput
       min={min}
       max={max}
+      step={isFloatingPoint ? 0.1 : 1}
+      disabled={disabled}
       value={values}
       type="number"
-      name={`filter-value-${id}`}
-      onChange={e => setData(e.target.value, id)}
+      name={`filter-value-${filter.id}`}
+      onChange={e => setData(e.target.value, filter.id, TYPE_VALUE)}
     />
-  ); 
-}
+  );
+};
 
 export default FilterValue;

--- a/src/packages/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -1,12 +1,17 @@
 import React from 'react';
-import Input from "styles-common/input";
+import Input from 'styles-common/input';
+import styled from 'styled-components';
+
+const StyledInput = styled(Input)`
+  text-align: left !important;
+`;
 
 const FilterValue = ({ filter, setData, id }) => {
 
   const { values, min, max } = filter;
 
   return (
-    <Input
+    <StyledInput
       min={min}
       max={max}
       value={values}

--- a/src/packages/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Input from "styles-common/input";
+
+const FilterValue = ({ filter, setData, id }) => {
+
+  const { values, min, max } = filter;
+
+  return (
+    <Input
+      min={min}
+      max={max}
+      value={values}
+      type="number"
+      name={`filter-value-${id}`}
+      onChange={e => setData(e.target.value, id)}
+    />
+  ); 
+}
+
+export default FilterValue;

--- a/src/packages/widget-editor/src/components/filter/components/FilterValue/index.js
+++ b/src/packages/widget-editor/src/components/filter/components/FilterValue/index.js
@@ -1,0 +1,3 @@
+import FilterValue from './component';
+
+export default FilterValue;

--- a/src/packages/widget-editor/src/components/filter/const.js
+++ b/src/packages/widget-editor/src/components/filter/const.js
@@ -1,33 +1,48 @@
-export const TYPE_RANGE = 'range';
-export const TYPE_VALUE = 'value';
-export const TYPE_COLUMNS = 'columns';
+import React from "react";
+
+export const TYPE_RANGE = "range";
+export const TYPE_VALUE = "value";
+export const TYPE_COLUMNS = "columns";
+export const TYPE_INDICATOR = "indicator";
 
 export const DEFAULT_RANGE_FILTER = {
-    indicator: TYPE_RANGE,
-    values: [0, 100],
-    type: TYPE_RANGE,
-    notNull: true,
-    max: 500,
-    min: 0
-}
+  values: [0, 100],
+  type: TYPE_RANGE,
+  notNull: true,
+  max: 500,
+  min: 0
+};
 
 export const DEFAULT_VALUE_FILTER = {
-    indicator: TYPE_VALUE,
-    values: 0,
-    type: TYPE_VALUE,
-    notNull: true,
-    max: 500,
-    min: 0
-}
+  values: 0,
+  type: TYPE_VALUE,
+  notNull: true,
+  max: 500,
+  min: 0
+};
 
 export const DEFAULT_COLUMNS_FILTER = {
-  indicator: TYPE_COLUMNS,
   values: [],
   type: TYPE_COLUMNS
-}
+};
+
+export const COLUMN_FILTER_GROUP = {
+  column: null,
+  label: null,
+  dataType: null,
+  indicator: TYPE_RANGE,
+  filter: DEFAULT_RANGE_FILTER
+};
+
+export const FILTER_TYPES = [
+  { label: "Between", value: TYPE_RANGE },
+  { label: "Equals", value: TYPE_VALUE }
+];
 
 export const DEFAULT_FILTERS = [
   DEFAULT_RANGE_FILTER,
   DEFAULT_VALUE_FILTER,
-  DEFAULT_COLUMNS_FILTER
+  DEFAULT_COLUMNS_FILTER,
+  FILTER_TYPES,
+  COLUMN_FILTER_GROUP
 ];

--- a/src/packages/widget-editor/src/components/filter/const.js
+++ b/src/packages/widget-editor/src/components/filter/const.js
@@ -1,0 +1,33 @@
+export const TYPE_RANGE = 'range';
+export const TYPE_VALUE = 'value';
+export const TYPE_COLUMNS = 'columns';
+
+export const DEFAULT_RANGE_FILTER = {
+    indicator: '',
+    values: [0, 100],
+    type: TYPE_RANGE,
+    notNull: true,
+    max: 500,
+    min: 0
+}
+
+export const DEFAULT_VALUE_FILTER = {
+    indicator: '',
+    values: 0,
+    type: TYPE_VALUE,
+    notNull: true,
+    max: 500,
+    min: 0
+}
+
+export const DEFAULT_COLUMNS_FILTER = {
+  indicator: '',
+  values: [],
+  type: TYPE_COLUMNS
+}
+
+export const DEFAULT_FILTERS = [
+  DEFAULT_RANGE_FILTER,
+  DEFAULT_VALUE_FILTER,
+  DEFAULT_COLUMNS_FILTER
+];

--- a/src/packages/widget-editor/src/components/filter/const.js
+++ b/src/packages/widget-editor/src/components/filter/const.js
@@ -3,7 +3,7 @@ export const TYPE_VALUE = 'value';
 export const TYPE_COLUMNS = 'columns';
 
 export const DEFAULT_RANGE_FILTER = {
-    indicator: '',
+    indicator: TYPE_RANGE,
     values: [0, 100],
     type: TYPE_RANGE,
     notNull: true,
@@ -12,7 +12,7 @@ export const DEFAULT_RANGE_FILTER = {
 }
 
 export const DEFAULT_VALUE_FILTER = {
-    indicator: '',
+    indicator: TYPE_VALUE,
     values: 0,
     type: TYPE_VALUE,
     notNull: true,
@@ -21,7 +21,7 @@ export const DEFAULT_VALUE_FILTER = {
 }
 
 export const DEFAULT_COLUMNS_FILTER = {
-  indicator: '',
+  indicator: TYPE_COLUMNS,
   values: [],
   type: TYPE_COLUMNS
 }

--- a/src/packages/widget-editor/src/components/filter/index.js
+++ b/src/packages/widget-editor/src/components/filter/index.js
@@ -1,15 +1,17 @@
 import { connectState } from "helpers/redux";
 
-import { patchConfiguration } from "modules/configuration/actions";
+import { setFilters } from "modules/filters/actions";
 
 import FilterComponent from "./component";
 
 export default connectState(
   state => ({
-    filters: state.configuration.filters,
-    fields: state.editor.fields,
+    configuration: state.configuration,
+    datasetId: state.editor.dataset.id,
+    filters: state.filters.list,
+    fields: state.editor.fields
   }),
-  { patchConfiguration }
+  { setFilters }
 )(FilterComponent);
 
-export * from './component';
+export * from "./component";

--- a/src/packages/widget-editor/src/components/filter/index.js
+++ b/src/packages/widget-editor/src/components/filter/index.js
@@ -1,0 +1,15 @@
+import { connectState } from "helpers/redux";
+
+import { patchConfiguration } from "modules/configuration/actions";
+
+import FilterComponent from "./component";
+
+export default connectState(
+  state => ({
+    filters: state.configuration.filters,
+    fields: state.editor.fields,
+  }),
+  { patchConfiguration }
+)(FilterComponent);
+
+export * from './component';

--- a/src/packages/widget-editor/src/components/filter/style.js
+++ b/src/packages/widget-editor/src/components/filter/style.js
@@ -11,53 +11,6 @@ export const StyledFilterBox = styled.div`
   }
 `;
 
-export const StyledAddSection = styled.div`
-  position: absolute;
-  top:-40px;
-  right: 0;
-`;
-
-export const StyledAddModal = styled.div`
-  position: absolute;
-  top: 40px;
-  right: 0;
-  width: 300px;
-  height: 100px;
-  background-color: white;
-  z-index: 3;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.09);
-  border-color: rgba(26,28,34,0.1);
-  border-style: solid;
-  border-width: 1px 1px 1px 1px;
-`;
-
-
-export const StyledIcons = styled.div`
-  display: flex;
-  align-items: stretch;
-  justify-content: flex-start;
-  height: 100%;
-  padding: 10px;
-`;
-
-export const StyledIconBox = styled.div`
-  width: 33.333%;
-  /* height: 100%; */
-  border-radius: 10px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  cursor: pointer;
-
-  padding-left: 10px;
-  padding-right: 10px;
-
-  button {
-    height:100%;
-  }
-`;
-
 export const StyledEmpty = styled.div`
   max-width: 300px;
   margin: 0 auto;
@@ -70,8 +23,19 @@ export const StyledEmpty = styled.div`
 export const StyledFilterSection = styled.div`
   padding: 30px 0 30px 30px;
   border-left: 1px solid rgba(26,28,34,0.1);
-
+  position: relative;
   label {
     text-transform: capitalize;
+  }
+`;
+
+export const StyledDeleteBox = styled.div`
+  position: absolute;
+  right: 0;
+  top: 15px;
+
+  button {
+    font-size: 12px;
+    padding: 7px 10px;
   }
 `;

--- a/src/packages/widget-editor/src/components/filter/style.js
+++ b/src/packages/widget-editor/src/components/filter/style.js
@@ -1,10 +1,77 @@
 import styled from 'styled-components';
 
 export const StyledFilterBox = styled.div`
+  position: relative;
+
   * {
     box-sizing: border-box;
   }
   input {
     box-sizing: border-box !important;
+  }
+`;
+
+export const StyledAddSection = styled.div`
+  position: absolute;
+  top:-40px;
+  right: 0;
+`;
+
+export const StyledAddModal = styled.div`
+  position: absolute;
+  top: 40px;
+  right: 0;
+  width: 300px;
+  height: 100px;
+  background-color: white;
+  z-index: 3;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.09);
+  border-color: rgba(26,28,34,0.1);
+  border-style: solid;
+  border-width: 1px 1px 1px 1px;
+`;
+
+
+export const StyledIcons = styled.div`
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-start;
+  height: 100%;
+  padding: 10px;
+`;
+
+export const StyledIconBox = styled.div`
+  width: 33.333%;
+  /* height: 100%; */
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  cursor: pointer;
+
+  padding-left: 10px;
+  padding-right: 10px;
+
+  button {
+    height:100%;
+  }
+`;
+
+export const StyledEmpty = styled.div`
+  max-width: 300px;
+  margin: 0 auto;
+  display: flex; 
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+`;
+
+export const StyledFilterSection = styled.div`
+  padding: 30px 0 30px 30px;
+  border-left: 1px solid rgba(26,28,34,0.1);
+
+  label {
+    text-transform: capitalize;
   }
 `;

--- a/src/packages/widget-editor/src/components/filter/style.js
+++ b/src/packages/widget-editor/src/components/filter/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 export const StyledFilterBox = styled.div`
   position: relative;
@@ -14,28 +14,36 @@ export const StyledFilterBox = styled.div`
 export const StyledEmpty = styled.div`
   max-width: 300px;
   margin: 0 auto;
-  display: flex; 
+  display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
 `;
 
 export const StyledFilterSection = styled.div`
-  padding: 30px 0 30px 30px;
-  border-left: 1px solid rgba(26,28,34,0.1);
+  padding: 10px 0;
   position: relative;
   label {
     text-transform: capitalize;
   }
 `;
 
+export const StyledFilter = styled.div`
+  padding: 15px 0 0 20px;
+  margin: 0 0 0 10px;
+  border-left: 1px solid #d2d3d6;
+`;
+
 export const StyledDeleteBox = styled.div`
   position: absolute;
   right: 0;
-  top: 15px;
+  top: 50%;
+  transform: translate(-50px, -50%);
 
   button {
     font-size: 12px;
     padding: 7px 10px;
+    border: none;
+    font-weight: 500;
   }
 `;

--- a/src/packages/widget-editor/src/components/filter/style.js
+++ b/src/packages/widget-editor/src/components/filter/style.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const StyledFilterBox = styled.div`
+  * {
+    box-sizing: border-box;
+  }
+  input {
+    box-sizing: border-box !important;
+  }
+`;

--- a/src/packages/widget-editor/src/components/query-limit/component.js
+++ b/src/packages/widget-editor/src/components/query-limit/component.js
@@ -5,32 +5,36 @@ import FormLabel from "styles-common/form-label";
 import Input from "styles-common/input";
 import styled from "styled-components";
 
+import isFloat from "helpers/isFloat";
+
 const StyledSliderBox = styled.div`
-  width:100%;
+  width: 100%;
   display: flex;
   padding: 20px 0;
 `;
 
 const StyledInputBox = styled.div`
-  width:100%;
+  width: 100%;
   display: flex;
   align-items: center;
-  justify-content: ${props => props.isDouble ? 'space-between' : 'flex-end'};
+  justify-content: ${props => (props.isDouble ? "space-between" : "flex-end")};
   input {
     max-width: 100px;
   }
 `;
 
-const QueryLimit = ({ 
-  label = "Label", 
-  min = 0, 
+const QueryLimit = ({
+  label,
+  min = 0,
   max = 500,
   value,
   minDistance = 1,
-  onChange = (data) => {},
-  handleOnChangeValue = (data, key) => {} 
+  onChange = data => {},
+  handleOnChangeValue = (data, key) => {}
 }) => {
   const isDouble = Array.isArray(value);
+  const isFloatingPoint = isFloat(min) || isFloat(max);
+
   let minValue = min;
   let maxValue = max;
   if (isDouble) {
@@ -46,14 +50,15 @@ const QueryLimit = ({
 
   return (
     <FlexContainer>
-      <FormLabel htmlFor="options-limit">{label}</FormLabel>
-      <StyledSliderBox>        
+      {label && <FormLabel htmlFor="options-limit">{label}</FormLabel>}
+      <StyledSliderBox>
         <Slider
           min={min}
           max={max}
+          step={isFloatingPoint ? 0.1 : 1}
           value={isDouble ? [minValue, maxValue] : maxValue}
           defaultValue={isDouble ? min : [min, max]}
-          onChange={(value) => onChange(value)}
+          onChange={value => onChange(value)}
         />
       </StyledSliderBox>
       <StyledInputBox isDouble={isDouble}>
@@ -64,7 +69,7 @@ const QueryLimit = ({
             value={minValue}
             type="number"
             name="options-limit"
-            onChange={e => handleOnChangeValue(e.target.value, 'minValue')}
+            onChange={e => handleOnChangeValue(e.target.value, "minValue")}
           />
         )}
         <Input
@@ -73,7 +78,7 @@ const QueryLimit = ({
           value={maxValue}
           type="number"
           name="options-limit"
-          onChange={e => handleOnChangeValue(e.target.value, 'maxValue')}
+          onChange={e => handleOnChangeValue(e.target.value, "maxValue")}
         />
       </StyledInputBox>
     </FlexContainer>

--- a/src/packages/widget-editor/src/components/slider/component.js
+++ b/src/packages/widget-editor/src/components/slider/component.js
@@ -3,7 +3,7 @@ import styled, { ThemeProvider } from "styled-components";
 import ReactSlider from "react-slider";
 
 const StyledSlider = styled(ReactSlider)`
-  height: 7px;
+  height: 4px;
   width: inherit;
 `;
 
@@ -15,6 +15,7 @@ const StyledThumb = styled.div`
   border: 3px solid ${props => props.theme.slider.track};
   border-radius: 50%;
   transform: translateY(-50%);
+  z-index: 0 !important;
   top: 50%;
   cursor: grab;
 `;
@@ -25,32 +26,38 @@ const StyledTrack = styled.div`
   background: ${props => {
     if (props.isArray) {
       return props.isArray && props.index === 1
-      ? props.theme.slider.track
-      : props.theme.slider.trackBackground
+        ? props.theme.slider.track
+        : props.theme.slider.trackBackground;
     } else {
       return props.index === 2
-      ? props.theme.slider.track
-      : props.index === 1
-      ? props.theme.slider.trackBackground
-      : props.theme.slider.track};
+        ? props.theme.slider.track
+        : props.index === 1
+        ? props.theme.slider.trackBackground
+        : props.theme.slider.track;
     }
-  };
+  }};
   border-radius: 999px;
 `;
 
 const Thumb = (props, state) => <StyledThumb {...props} />;
-const Track = (props, state) => <StyledTrack {...props} isArray={Array.isArray(state.value)} index={state.index} />;
+const Track = (props, state) => (
+  <StyledTrack
+    {...props}
+    isArray={Array.isArray(state.value)}
+    index={state.index}
+  />
+);
 
 const Slider = ({
   min = 1,
   max = 500,
+  step = 1,
   value,
   defaultValue,
   theme,
   onChange = () => {},
-  onDone = () => {},
+  onDone = () => {}
 }) => {
-
   return (
     <ThemeProvider theme={theme}>
       <StyledSlider
@@ -59,6 +66,7 @@ const Slider = ({
         renderTrack={Track}
         renderThumb={Thumb}
         value={value}
+        step={step}
         defaultValue={defaultValue}
         max={max}
         min={min}

--- a/src/packages/widget-editor/src/helpers/isFloat.js
+++ b/src/packages/widget-editor/src/helpers/isFloat.js
@@ -1,0 +1,3 @@
+export default function isFloat(n) {
+  return Number(n) === n && n % 1 !== 0;
+}

--- a/src/packages/widget-editor/src/modules/configuration/initial-state.js
+++ b/src/packages/widget-editor/src/modules/configuration/initial-state.js
@@ -8,5 +8,5 @@ export default {
     { value: "bar", label: "Bars" },
     { value: "line", label: "Line" },
     { value: "scatter", label: "Scatter" }
-  ]
+  ],
 };

--- a/src/packages/widget-editor/src/modules/filters/actions.js
+++ b/src/packages/widget-editor/src/modules/filters/actions.js
@@ -1,0 +1,7 @@
+import { createAction } from "helpers/redux";
+
+export const setFilters = createAction("EDITOR/setFilters");
+
+export default {
+  setFilters
+};

--- a/src/packages/widget-editor/src/modules/filters/index.js
+++ b/src/packages/widget-editor/src/modules/filters/index.js
@@ -1,0 +1,5 @@
+import * as actions from "./actions";
+import * as reducers from "./reducers";
+import initialState from "./initial-state";
+
+export { actions, initialState, reducers };

--- a/src/packages/widget-editor/src/modules/filters/initial-state.js
+++ b/src/packages/widget-editor/src/modules/filters/initial-state.js
@@ -1,0 +1,3 @@
+export default {
+  list: []
+};

--- a/src/packages/widget-editor/src/modules/filters/reducers.js
+++ b/src/packages/widget-editor/src/modules/filters/reducers.js
@@ -1,0 +1,5 @@
+import * as actions from "./actions";
+
+export default {
+  [actions.setFilters]: (state, { payload }) => ({ ...state, ...payload })
+};

--- a/src/packages/widget-editor/src/modules/index.js
+++ b/src/packages/widget-editor/src/modules/index.js
@@ -1,17 +1,19 @@
 import { combineReducers } from "redux";
 import { handleModule } from "vizzuality-redux-tools";
 
-import { constants } from '@packages/core';
+import { constants } from "@packages/core";
 
 import * as editor from "modules/editor";
 import * as theme from "modules/theme";
 import * as widget from "modules/widget";
 import * as configuration from "modules/configuration";
+import * as filters from "modules/filters";
 
 const modules = {
   configuration: handleModule(configuration),
   editor: handleModule(editor),
   theme: handleModule(theme),
+  filters: handleModule(filters),
   widget: handleModule(widget)
 };
 

--- a/src/packages/widget-editor/src/styles-common/input-group.js
+++ b/src/packages/widget-editor/src/styles-common/input-group.js
@@ -1,8 +1,10 @@
 import styled from "styled-components";
 
 const InputGroup = styled.div`
+  position: relative;
   width: 100%;
-  margin: 0 0 15px 0;
+
+  ${props => !props.noMargins && "margin: 0 0 15px 0;"}
 `;
 
 export default InputGroup;

--- a/src/packages/widget-editor/src/styles-common/input.js
+++ b/src/packages/widget-editor/src/styles-common/input.js
@@ -14,7 +14,7 @@ const Input = styled.input`
 
   &[type="number"] {
     box-sizing: content-box;
-    text-align: center;
+    padding: 8px 10px;
   }
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3750,6 +3750,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-css@4.2.x:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
@@ -8126,6 +8131,11 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash-es@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -10454,7 +10464,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10593,6 +10603,11 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
+raf-schd@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
+  integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -10711,6 +10726,14 @@ react-dom@^16.12.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
+react-draggable@^4.0.3:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.2.0.tgz#40cc5209082ca7d613104bf6daf31372cc0e1114"
+  integrity sha512-5wFq//gEoeTYprnd4ze8GrFc+Rbnx+9RkOMR3vk4EbWxj02U6L6T3yrlKeiw4X5CtjD2ma2+b3WujghcXNRzkw==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
+
 react-error-overlay@^6.0.3:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.5.tgz#55d59c2a3810e8b41922e0b4e5f85dcf239bd533"
@@ -10751,6 +10774,25 @@ react-redux@^7.1.3:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
+
+react-resizable@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-1.10.1.tgz#f0c2cf1d83b3470b87676ce6d6b02bbe3f4d8cd4"
+  integrity sha512-Jd/bKOKx6+19NwC4/aMLRu/J9/krfxlDnElP41Oc+oLiUWs/zwV1S9yBfBZRnqAwQb6vQ/HRSk3bsSWGSgVbpw==
+  dependencies:
+    prop-types "15.x"
+    react-draggable "^4.0.3"
+
+react-resize-detector@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-4.2.1.tgz#8982b74c3e1cf949afaa3c41050458c87b033982"
+  integrity sha512-ZfPMBPxXi0o3xox42MIEtz84tPSVMW9GgwLHYvjVXlFM+OkNzbeEtpVSV+mSTJmk4Znwomolzt35zHN9LNBQMQ==
+  dependencies:
+    lodash "^4.17.15"
+    lodash-es "^4.17.15"
+    prop-types "^15.7.2"
+    raf-schd "^4.0.2"
+    resize-observer-polyfill "^1.5.1"
 
 react-scripts@3.2.0:
   version "3.2.0"
@@ -11288,6 +11330,11 @@ reselect@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3750,11 +3750,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
-
 clean-css@4.2.x:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
@@ -10464,7 +10459,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10726,14 +10721,6 @@ react-dom@^16.12.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react-draggable@^4.0.3:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.2.0.tgz#40cc5209082ca7d613104bf6daf31372cc0e1114"
-  integrity sha512-5wFq//gEoeTYprnd4ze8GrFc+Rbnx+9RkOMR3vk4EbWxj02U6L6T3yrlKeiw4X5CtjD2ma2+b3WujghcXNRzkw==
-  dependencies:
-    classnames "^2.2.5"
-    prop-types "^15.6.0"
-
 react-error-overlay@^6.0.3:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.5.tgz#55d59c2a3810e8b41922e0b4e5f85dcf239bd533"
@@ -10774,14 +10761,6 @@ react-redux@^7.1.3:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
-
-react-resizable@^1.10.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-1.10.1.tgz#f0c2cf1d83b3470b87676ce6d6b02bbe3f4d8cd4"
-  integrity sha512-Jd/bKOKx6+19NwC4/aMLRu/J9/krfxlDnElP41Oc+oLiUWs/zwV1S9yBfBZRnqAwQb6vQ/HRSk3bsSWGSgVbpw==
-  dependencies:
-    prop-types "15.x"
-    react-draggable "^4.0.3"
 
 react-resize-detector@^4.2.1:
   version "4.2.1"


### PR DESCRIPTION
This PR adds filters to widget-editor.
Features: 
- Add, Edit, Delete 3 filter types (value, range, column). No way to add filters with the 2 same types
- Accordion adaptive height
- redux data control
## Testing instructions
Run widget-editor app. Open filters tab. Add filters to the section. Try to edit and delete them.
