### PR TITLE
Added a compact mode

### DIFF
--- a/src/packages/widget-editor/src/components/editor-options/component.js
+++ b/src/packages/widget-editor/src/components/editor-options/component.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { Accordion, AccordionSection } from "components/accordion";
 import { Tabs, Tab } from "components/tabs";
 
@@ -19,9 +19,28 @@ const StyledContainer = styled.div`
   margin: 10px 0;
   overflow-y: scroll;
   ${DEFAULT_BORDER(1, 1, 1, 0)}
+  ${props => props.compact.isCompact && 
+    css`
+      visibility: hidden;
+      /* z-index: -1; */
+      max-height: 0;
+      position: absolute;
+      top: 65px;
+      left: 0; 
+      margin: 0;
+      width: 100%;
+      transition: all 0.3s ease-in-out;
+    `}
+  ${props => props.compact.isCompact && props.compact.isOpen &&
+  css`
+    display: block;
+    z-index: auto;
+    visibility: visible;
+    max-height: calc(100% - ${FOOTER_HEIGHT} - 65px);
+  `}
 `;
 
-const EditorOptions = ({ orderBy }) => {
+const EditorOptions = ({ orderBy, compact }) => {
 
   const [minValue, setMinValue] = useState(10);
   const [maxValue, setMaxValue] = useState(40);
@@ -35,7 +54,7 @@ const EditorOptions = ({ orderBy }) => {
   }
 
   return (
-    <StyledContainer>
+    <StyledContainer compact={compact}>
       <Tabs>
         <Tab label="General">
           <Accordion>

--- a/src/packages/widget-editor/src/components/editor-options/index.js
+++ b/src/packages/widget-editor/src/components/editor-options/index.js
@@ -1,13 +1,12 @@
 import { connectState } from "helpers/redux";
-
 import { patchConfiguration } from "modules/configuration/actions";
-
 import EditorOptionsComponent from "./component";
 
 export default connectState(
   state => ({
     limit: state.configuration.limit,
-    orderBy: state.configuration.orderBy
+    orderBy: state.configuration.orderBy,
+    compact: state.theme.compact
   }),
   { patchConfiguration }
 )(EditorOptionsComponent);

--- a/src/packages/widget-editor/src/components/editor/component.js
+++ b/src/packages/widget-editor/src/components/editor/component.js
@@ -1,42 +1,25 @@
 import React from "react";
-import styled from "styled-components";
 import isEqual from "lodash/isEqual";
 import debounce from "lodash/debounce";
-
 import Renderer from "components/renderer";
 import EditorOptions from "components/editor-options";
 import Footer from "components/footer";
-
 import { DataService } from "@packages/core";
-
 import { constants } from "@packages/core";
-
-const StyledContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-flow: wrap;
-  justify-content: space-between;
-  flex-flow: column;
-
-  @media only screen and (min-width: 768px) {
-    flex-flow: wrap;
-  }
-`;
+import { StyledContainer } from './style';
 
 class Editor extends React.Component {
   constructor(props) {
     super(props);
-    const { onSave, datasetId, adapter, setEditor, dispatch } = this.props;
-
+    const { datasetId, adapter, setEditor, dispatch, theme } = this.props;
     this.onSave = this.onSave.bind(this);
-
     this.dataService = new DataService(datasetId, adapter, setEditor, dispatch);
     this.dataService.resolveInitialState();
+    this.resolveTheme(theme);
   }
 
   componentWillMount() {
-    const { authenticated, dispatch } = this.props;
+    const { authenticated } = this.props;
     if (authenticated) {
       this.resolveAuthentication();
     }
@@ -91,9 +74,9 @@ class Editor extends React.Component {
   }
 
   render() {
-    const { configuration } = this.props;
+    const { configuration, theme: { compact } } = this.props;
     return (
-      <StyledContainer>
+      <StyledContainer {...compact} >
         <Renderer />
         {configuration.limit && <EditorOptions />}
         <Footer onSave={this.onSave} />

--- a/src/packages/widget-editor/src/components/editor/index.js
+++ b/src/packages/widget-editor/src/components/editor/index.js
@@ -16,7 +16,7 @@ export default connectState(
     return {
       dispatch,
       setEditor: data => dispatch(setEditor(data)),
-      setTheme: data => dispatch(setTheme(data))
+      setTheme: data => dispatch(setTheme(data)),
     };
   }
 )(EditorComponent);

--- a/src/packages/widget-editor/src/components/editor/style.js
+++ b/src/packages/widget-editor/src/components/editor/style.js
@@ -1,0 +1,28 @@
+import styled, { css } from 'styled-components';
+import { FOOTER_HEIGHT } from 'style-constants';
+
+export const StyledContainer = styled.div`
+  width: 100%;
+  box-sizing: border-box;
+  *, *:after, *:before {
+    box-sizing: border-box;
+  }
+  
+  ${props => props.isCompact
+  ? css`
+    position: relative;
+    max-width: 600px;
+    margin: 0 auto;
+    height: calc(100% - ${FOOTER_HEIGHT});      
+  ` 
+  : css`
+    height: 100%;
+    display: flex;
+    flex-flow: wrap;
+    justify-content: space-between;
+    flex-flow: column;
+    @media only screen and (min-width: 768px) {
+      flex-flow: wrap;
+    }
+  `}
+`;

--- a/src/packages/widget-editor/src/components/renderer/component.js
+++ b/src/packages/widget-editor/src/components/renderer/component.js
@@ -1,34 +1,13 @@
 import React from "react";
-import styled from "styled-components";
-import isEmpty from "lodash/isEmpty";
 
 import Chart from "components/chart";
 import QueryValues from "components/query-values";
 import SelectChart from "components/select-chart";
-
-import { FOOTER_HEIGHT, DEFAULT_BORDER } from "style-constants";
-
-const StyledContainer = styled.div`
-  display: flex;
-  flex-flow: column;
-  height: calc(100% - ${FOOTER_HEIGHT});
-  background: #fff;
-  flex: 1;
-  width: 100%;
-  ${DEFAULT_BORDER()}
-`;
-
-const RestoringWidget = styled.div`
-  height: 300px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`
-
-const RestoringWidgetTitle = styled.h4`
-  color: #a9a9a9;
-  font-size: 21px;
-`
+import {
+  StyledContainer,
+  RestoringWidget,
+  RestoringWidgetTitle
+} from './style';
 
 const Renderer = ({ widget, editor }) => {
   const { restoring, initialized } = editor;

--- a/src/packages/widget-editor/src/components/renderer/index.js
+++ b/src/packages/widget-editor/src/components/renderer/index.js
@@ -2,13 +2,10 @@
 // It should be possible to use the renderer without the editor!
 import { connectState } from "helpers/redux";
 
-import { setEditor } from "modules/editor/actions";
-import { setTheme } from "modules/theme/actions";
-
 // Components
 import RendererComponent from "./component";
 
 export default connectState(state => ({
   editor: state.editor,
-  widget: state.widget
+  widget: state.widget,
 }))(RendererComponent);

--- a/src/packages/widget-editor/src/components/renderer/style.js
+++ b/src/packages/widget-editor/src/components/renderer/style.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import { FOOTER_HEIGHT, DEFAULT_BORDER } from 'style-constants';
+
+export const StyledContainer = styled.div`
+  display: flex;
+  flex-flow: column;
+  height: calc(100% - ${FOOTER_HEIGHT});
+  background: #fff;
+  flex: 1;
+  width: 100%;
+  ${DEFAULT_BORDER()}
+`;
+
+export const RestoringWidget = styled.div`
+  height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+export const RestoringWidgetTitle = styled.h4`
+  color: #a9a9a9;
+  font-size: 21px;
+`

--- a/src/packages/widget-editor/src/components/select-chart/component.js
+++ b/src/packages/widget-editor/src/components/select-chart/component.js
@@ -1,30 +1,14 @@
 import React, { useState, useEffect } from "react";
-import styled from "styled-components";
 import find from "lodash/find";
 import isEqual from "lodash/isEqual";
-
+import Button from "components/button";
 import Select from "react-select";
+import { StyledContainer, StyledSelectBox, InputStyles } from './style';
 
-const StyledContainer = styled.div`
-  margin: 10px;
-`;
 
-const InputStyles = {
-  control: () => ({
-    // none of react-select's styles are passed to <Control />
-    display: "flex",
-    border: "1px solid rgba(202,204,208,0.85)",
-    borderRadius: "4px",
-    padding: "3px 0"
-  }),
-  option: base => ({
-    ...base
-  })
-};
-
-const SelectChart = ({ patchConfiguration, options, value }) => {
+const SelectChart = ({ patchConfiguration, options, value, theme, setTheme }) => {
   const [selected, setSelected] = useState(find(options, { value }));
-
+  const { compact: { isCompact, isOpen } } = theme;
   useEffect(() => {
     // TODO: optimize...
     if (!isEqual(find(options, { value }), selected)) {
@@ -36,14 +20,28 @@ const SelectChart = ({ patchConfiguration, options, value }) => {
     patchConfiguration({ chartType: option.value });
   };
 
+  const hadleSettings = () => {
+    setTheme({...theme, compact: { isCompact, isOpen: !isOpen }})
+  }
+
   return (
-    <StyledContainer>
-      <Select
-        onChange={handleChange}
-        value={selected}
-        options={options}
-        styles={InputStyles}
-      />
+    <StyledContainer isCompact={isCompact}>
+      <StyledSelectBox isCompact={isCompact}>
+        <Select
+          onChange={handleChange}
+          value={selected}
+          options={options}
+          styles={InputStyles}
+        />
+      </StyledSelectBox>
+      {isCompact && (
+        <Button
+          type="highlight"
+          onClick={()=> hadleSettings()}
+        >
+          Settings
+        </Button>
+      )}
     </StyledContainer>
   );
 };

--- a/src/packages/widget-editor/src/components/select-chart/index.js
+++ b/src/packages/widget-editor/src/components/select-chart/index.js
@@ -1,6 +1,7 @@
 import { connectState } from "helpers/redux";
 
 import { patchConfiguration } from "modules/configuration/actions";
+import { setTheme } from "modules/theme/actions";
 
 // Components
 import SelectChartComponent from "./component";
@@ -8,7 +9,8 @@ import SelectChartComponent from "./component";
 export default connectState(
   state => ({
     options: state.configuration.availableCharts,
-    value: state.configuration.chartType
+    value: state.configuration.chartType,
+    theme: state.theme,
   }),
-  { patchConfiguration }
+  { patchConfiguration, setTheme }
 )(SelectChartComponent);

--- a/src/packages/widget-editor/src/components/select-chart/style.js
+++ b/src/packages/widget-editor/src/components/select-chart/style.js
@@ -1,0 +1,32 @@
+
+import styled, { css } from "styled-components";
+
+export const StyledContainer = styled.div`
+  margin: 10px;
+  ${props => props.isCompact && 
+  css`
+    display: flex;
+    align-items: center;
+  `}
+`;
+
+export const StyledSelectBox = styled.div`
+  ${props => props.isCompact && 
+  css`
+    width: 100%;
+    padding-right: 15px;
+  `}
+`;
+
+export const InputStyles = {
+  control: () => ({
+    // none of react-select's styles are passed to <Control />
+    display: "flex",
+    border: "1px solid rgba(202,204,208,0.85)",
+    borderRadius: "4px",
+    padding: "3px 0"
+  }),
+  option: base => ({
+    ...base
+  })
+};

--- a/src/packages/widget-editor/src/components/widget-editor/component.js
+++ b/src/packages/widget-editor/src/components/widget-editor/component.js
@@ -1,11 +1,9 @@
-import { Provider } from "react-redux";
-
 import React from "react";
 import Editor from "components/editor";
 
 class WidgetEditor extends React.Component {
   render() {
-    const { authenticated, onSave, datasetId, adapter, theme } = this.props;
+    const { authenticated, onSave, datasetId, adapter, theme, compact = true } = this.props;
 
     if (typeof adapter !== "function") {
       throw new Error(
@@ -19,7 +17,13 @@ class WidgetEditor extends React.Component {
         onSave={onSave}
         datasetId={datasetId}
         adapter={new adapter()}
-        theme={theme}
+        theme={{
+          ...theme, 
+          compact: { 
+            isCompact: compact,
+            isOpen: false 
+          }
+        }}
       />
     );
   }

--- a/src/packages/widget-editor/src/modules/theme/initial-state.js
+++ b/src/packages/widget-editor/src/modules/theme/initial-state.js
@@ -1,4 +1,8 @@
 export default {
+  compact: {
+    isCompact: false,
+    isOpen: false,
+  },
   color: "#C32D7B",
   slider: {
     track: "#a3daf3",


### PR DESCRIPTION
This PR adds a compact mode to widgetEditor.
## Testing instructions
Run widget-editor application. 
Set prop compact to true in packages->widget-editor->components->widget-editor
Use a compact version in Browser.
### [Pivotal](https://www.pivotaltracker.com/n/projects/2154258/stories/171748236)