### PR TITLE
Visual style tab - typography and accordions

### DIFF
--- a/src/packages/widget-editor/src/components/accordion/component.js
+++ b/src/packages/widget-editor/src/components/accordion/component.js
@@ -46,7 +46,9 @@ export const AccordionSection = ({ title, openDefault, children }) => {
           skipOnMount
           onResize={updateHeight}
         >
-          {children}
+          <div>
+            {children}
+          </div>
         </ReactResizeDetector>
       </StyledAccordionContent>
     </StyledAccordionSection>

--- a/src/packages/widget-editor/src/components/color-shemes/component.js
+++ b/src/packages/widget-editor/src/components/color-shemes/component.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import {
+  StyledShemesContainer,
+  StyledShemesCard,
+  StyledCardBox,
+  StyledShemeName,
+  StyledShemeInfo,
+  StyledShemeColors,
+} from './style';
+
+const ColorShemes = ({ theme, setTheme }) => {
+
+  const { schemes, selectedScheme } = theme;
+
+  const onChangeTheme = (sheme) => {
+    setTheme({ ...theme, selectedScheme: sheme.name });
+  }
+
+  return (
+    <StyledShemesContainer>
+      {schemes.map(sheme => {
+        return (
+          <StyledShemesCard key={sheme.name}>
+            <StyledCardBox active={selectedScheme === sheme.name} onClick={() => onChangeTheme(sheme)}>
+              <StyledShemeInfo>
+                <StyledShemeName>{sheme.name}</StyledShemeName>
+                <StyledShemeColors>
+                  <div style={{ flexBasis: '100%', background: sheme.mainColor }} />
+                  <div style={{ flexBasis: '100%', display: 'flex' }}>
+                    {sheme.category.map(color => (
+                      <div key={color} style={{ flexBasis: `${100 / sheme.category.length}%`, background: color }} />
+                    ))}
+                  </div>
+                </StyledShemeColors>
+              </StyledShemeInfo>
+            </StyledCardBox>
+            
+          </StyledShemesCard>
+        )
+      })}
+    </StyledShemesContainer>
+  );
+  
+}
+
+export default ColorShemes;

--- a/src/packages/widget-editor/src/components/color-shemes/index.js
+++ b/src/packages/widget-editor/src/components/color-shemes/index.js
@@ -1,0 +1,10 @@
+import { connectState } from "helpers/redux";
+import { setTheme } from "modules/theme/actions";
+import ColorShemes from "./component";
+
+export default connectState(
+  state => ({
+    theme: state.theme
+  }),
+  { setTheme }
+)(ColorShemes);

--- a/src/packages/widget-editor/src/components/color-shemes/style.js
+++ b/src/packages/widget-editor/src/components/color-shemes/style.js
@@ -1,0 +1,59 @@
+import styled, { css } from 'styled-components';
+
+export const StyledShemesContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  width: 100%;
+  margin-left: -5px;
+  margin-right: -5px;
+
+  * {
+    box-sizing: border-box;
+  }
+`;
+export const StyledShemesCard = styled.div`
+  width: 33.333%;  
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-right: 5px;
+  padding-left: 5px;
+  input  {
+    display: none;
+  }
+`;
+
+export const StyledCardBox = styled.div`
+  width: 100%;
+  box-sizing: border-box;
+  height: 100px;
+  border: ${props => props.active ? '2px solid #C32D7B' : '1px solid rgba(202,204,208,0.85)'};
+  border-radius: 4px;
+  background-color: rgba(255,255,255,0);
+  padding: 15px 18px;
+
+  &:hover {
+    border: 2px solid #C32D7B;
+    cursor: pointer;
+  }
+`;
+
+export const StyledShemeInfo = styled.div`
+
+`;
+
+export const StyledShemeName = styled.div`
+  font-size: 14px;
+  margin: 0;
+  padding-bottom: 7px;
+  text-transform: uppercase;
+`;
+
+
+export const StyledShemeColors = styled.div`
+  div {
+    height: 21px;
+  }
+`;

--- a/src/packages/widget-editor/src/components/editor-options/component.js
+++ b/src/packages/widget-editor/src/components/editor-options/component.js
@@ -9,6 +9,7 @@ import TableView from "components/table-view";
 import JsonEditor from "components/json-editor";
 import Filter from "components/filter";
 import Typography from "components/typography";
+import ColorShemes from "components/color-shemes";
 
 import { FOOTER_HEIGHT, DEFAULT_BORDER } from "style-constants";
 
@@ -64,11 +65,11 @@ const EditorOptions = ({ orderBy, compact }) => {
         </Tab>
         <Tab label="Visual style" default >
           <Accordion>
-            <AccordionSection title="Typography" openDefault >
+            <AccordionSection title="Typography" >
               <Typography />
             </AccordionSection>
-            <AccordionSection title="Color">
-              Color
+            <AccordionSection title="Color" openDefault>
+              <ColorShemes />
             </AccordionSection>
           </Accordion>
         </Tab>

--- a/src/packages/widget-editor/src/components/editor-options/component.js
+++ b/src/packages/widget-editor/src/components/editor-options/component.js
@@ -8,6 +8,7 @@ import OrderValues from "components/order-values";
 import TableView from "components/table-view";
 import JsonEditor from "components/json-editor";
 import Filter from "components/filter";
+import Typography from "components/typography";
 
 import { FOOTER_HEIGHT, DEFAULT_BORDER } from "style-constants";
 
@@ -50,7 +51,7 @@ const EditorOptions = ({ orderBy, compact }) => {
       <Tabs>
         <Tab label="General">
           <Accordion>
-            <AccordionSection title="Description and labels" openDefault>
+            <AccordionSection title="Description and labels">
               <WidgetInfo />
             </AccordionSection>
             <AccordionSection title="Filters">
@@ -61,7 +62,16 @@ const EditorOptions = ({ orderBy, compact }) => {
             </AccordionSection>
           </Accordion>
         </Tab>
-        <Tab label="Visual style">Visual style</Tab>
+        <Tab label="Visual style" default >
+          <Accordion>
+            <AccordionSection title="Typography" openDefault >
+              <Typography />
+            </AccordionSection>
+            <AccordionSection title="Color">
+              Color
+            </AccordionSection>
+          </Accordion>
+        </Tab>
         <Tab label="Advanced">
           <JsonEditor />
         </Tab>

--- a/src/packages/widget-editor/src/components/typography/component.js
+++ b/src/packages/widget-editor/src/components/typography/component.js
@@ -1,64 +1,73 @@
 import React from 'react';
-import FlexContainer from "styles-common/flex";
-import FormLabel from "styles-common/form-label";
-import InputGroup from "styles-common/input-group";
-import Input from "styles-common/input";
-import Select from "react-select";
+import FlexContainer from 'styles-common/flex';
+import FormLabel from 'styles-common/form-label';
+import InputGroup from 'styles-common/input-group';
+import Input from 'styles-common/input';
+import Select from 'react-select';
+import { FONTS } from './const';
+import { InputStyles } from './style';
 
-export const InputStyles = {
-  control: () => ({
-    // none of react-select's styles are passed to <Control />
-    display: "flex",
-    border: "1px solid rgba(202,204,208,0.85)",
-    borderRadius: "4px",
-    padding: "3px 0"
-  }),
-  option: base => ({
-    ...base
-  })
-};
-
-const Typography = ({ theme }) => {
+const Typography = ({ theme, setTheme }) => {
 
   const {
-    selectedScheme,
     font,
     titleSize,
     captionSize,
     axisTitleSize,
-    schemes,
   } = theme;
 
-  const handleChange = option => {
-    // patchConfiguration({ chartType: option.value });
+  const selectedFont = FONTS.find(f => f.value === font) || FONTS[0];
+
+  const handleChangeFont = option => {
+    setTheme({ ...theme, font: option.value });
   };
 
-  const options = [
-    { value: 'value-1', label: 'Value-1' },
-    { value: 'value-2', label: 'Value-2' },
-  ];
+  const handleChangeSize = (key, value) => {
+    const reg = new RegExp('^[0-9]*$');
+    const setValue = value !== '' && reg.test(Number(value)) ? value : 'auto';
+    setTheme({ ...theme, [key]: setValue });
+  }
 
   return (
     <div>
         <FormLabel htmlFor="options-title">Font</FormLabel>
         <Select
-          onChange={handleChange}
-          options={options}
+          value={selectedFont}
+          onChange={handleChangeFont}
+          options={FONTS}
           styles={InputStyles}
         />
         <br />
         <FlexContainer row={true}>
           <InputGroup>
-            <FormLabel htmlFor="options-title">Title size</FormLabel>
-            <Input />
+            <FormLabel htmlFor="typography-title-size">Title size</FormLabel>
+            <Input 
+              name="typography-title-size" 
+              value={titleSize === "auto" ? '' : titleSize}
+              type="text"
+              onChange={e => handleChangeSize('titleSize', e.target.value)}
+              placeholder="Auto"
+            />
           </InputGroup>
           <InputGroup>
-            <FormLabel htmlFor="options-title">Caption size</FormLabel>
-            <Input />
+            <FormLabel htmlF  or="typography-caption-size">Caption size</FormLabel>
+            <Input 
+              name="typography-caption-size" 
+              value={captionSize === "auto" ? '' : captionSize}
+              type="text"
+              onChange={e => handleChangeSize('captionSize', e.target.value)}
+              placeholder="Auto"
+            />
           </InputGroup>
           <InputGroup>
-            <FormLabel htmlFor="options-title">Axis title size</FormLabel>
-            <Input />
+            <FormLabel htmlFor="typography-axisTitleSize">Axis title size</FormLabel>
+            <Input 
+               name="typography-axisTitleSize" 
+               value={axisTitleSize === "auto" ? '' : axisTitleSize}
+               type="text"
+               onChange={e => handleChangeSize('axisTitleSize', e.target.value)}
+               placeholder="Auto"
+            />
           </InputGroup>
         </FlexContainer>      
     </div>

--- a/src/packages/widget-editor/src/components/typography/component.js
+++ b/src/packages/widget-editor/src/components/typography/component.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import FlexContainer from "styles-common/flex";
+import FormLabel from "styles-common/form-label";
+import InputGroup from "styles-common/input-group";
+import Input from "styles-common/input";
+import Select from "react-select";
+
+export const InputStyles = {
+  control: () => ({
+    // none of react-select's styles are passed to <Control />
+    display: "flex",
+    border: "1px solid rgba(202,204,208,0.85)",
+    borderRadius: "4px",
+    padding: "3px 0"
+  }),
+  option: base => ({
+    ...base
+  })
+};
+
+const Typography = ({ theme }) => {
+
+  const {
+    selectedScheme,
+    font,
+    titleSize,
+    captionSize,
+    axisTitleSize,
+    schemes,
+  } = theme;
+
+  const handleChange = option => {
+    // patchConfiguration({ chartType: option.value });
+  };
+
+  const options = [
+    { value: 'value-1', label: 'Value-1' },
+    { value: 'value-2', label: 'Value-2' },
+  ];
+
+  return (
+    <div>
+        <FormLabel htmlFor="options-title">Font</FormLabel>
+        <Select
+          onChange={handleChange}
+          options={options}
+          styles={InputStyles}
+        />
+        <br />
+        <FlexContainer row={true}>
+          <InputGroup>
+            <FormLabel htmlFor="options-title">Title size</FormLabel>
+            <Input />
+          </InputGroup>
+          <InputGroup>
+            <FormLabel htmlFor="options-title">Caption size</FormLabel>
+            <Input />
+          </InputGroup>
+          <InputGroup>
+            <FormLabel htmlFor="options-title">Axis title size</FormLabel>
+            <Input />
+          </InputGroup>
+        </FlexContainer>      
+    </div>
+  );
+}
+
+
+
+export default Typography;

--- a/src/packages/widget-editor/src/components/typography/const.js
+++ b/src/packages/widget-editor/src/components/typography/const.js
@@ -1,0 +1,4 @@
+export const FONTS = [
+  { value: 'lato', label: 'Lato' },
+  { value: 'arial', label: 'Arial' }
+];

--- a/src/packages/widget-editor/src/components/typography/index.js
+++ b/src/packages/widget-editor/src/components/typography/index.js
@@ -1,0 +1,10 @@
+import { connectState } from "helpers/redux";
+import { setTheme } from "modules/theme/actions";
+import Typography from "./component";
+
+export default connectState(
+  state => ({
+    theme: state.theme
+  }),
+  { setTheme }
+)(Typography);

--- a/src/packages/widget-editor/src/components/typography/style.js
+++ b/src/packages/widget-editor/src/components/typography/style.js
@@ -1,0 +1,39 @@
+export const InputStyles = {
+
+  container: () => ({
+    position: "relative",
+    boxSizing: "border-box",
+    cursor: "pointer",
+    border: "1px solid rgba(202,204,208,0.85)",
+    borderRadius: "4px",
+    backgroundColor: "rgba(255,255,255,0)",
+  }),
+
+  indicatorSeparator: () => ({
+    display: "none",
+  }),
+
+  dropdownIndicator: (provided, state) => {
+    return ({
+      color: "#c32d7b",
+      transition: "all 0.2s ease-out",    
+    });
+  },
+
+  indicatorsContainer: () => ({
+    color: "#c32d7b",
+    display: "flex",
+    padding: "8px",
+    transition: "color 150ms",
+    boxSizing: "border-box",
+    position: "relative",
+    top: "5px",
+  }),
+
+  control: () => ({
+    display: "flex",
+    border: "none",
+    borderRadius: "4px",
+    padding: "3px 0"
+  })
+};

--- a/src/packages/widget-editor/src/modules/theme/initial-state.js
+++ b/src/packages/widget-editor/src/modules/theme/initial-state.js
@@ -30,5 +30,10 @@ export default {
   slider: {
     track: "#a3daf3",
     trackBackground: "#f5f5f5"
-  }
+  },
+  selectedScheme: 'default',
+  font: 'lato',
+  titleSize: 'auto',
+  captionSize: 'auto',
+  axisTitleSize: 'auto'
 };


### PR DESCRIPTION
This PR adds 2 accordions to the visual style tab: typography and color. They update data in widgetEditor->theme reducer.
## Testing instructions
Run widget-editor app. Open Visual style tab. Check Typography and Color accordion. Try to change data on it.
## [Pivotal Tracker](https://www.pivotaltracker.com/n/projects/2154258/stories/171770911)