### PR TITLE
Fix issues with the ORDER BY statement of the queries

### DIFF
--- a/src/applications/widget-editor/src/components/order-values/component.js
+++ b/src/applications/widget-editor/src/components/order-values/component.js
@@ -30,13 +30,13 @@ const ORDER_TYPES = [
 
 const OrderValues = ({ orderBy, columns, setFilters, onChange }) => {
   const options = columns.map((c) => ({
-    value: c.name || c.alias || c.identifier,
-    label: c.name || c.alias || c.identifier,
+    value: c.name,
+    label: c.alias || c.name || c.identifier,
   }));
 
-  const selectedOption = options.find((o) =>
-    orderBy ? o.label === orderBy.name : null
-  );
+  const selectedOption = orderBy
+    ? options.find(option => option.value === orderBy.name)
+    : null;
 
   let selectedOrder;
   if (orderBy && orderBy.orderType) {

--- a/src/applications/widget-editor/src/components/order-values/component.js
+++ b/src/applications/widget-editor/src/components/order-values/component.js
@@ -45,7 +45,7 @@ const OrderValues = ({ orderBy, columns, setFilters, onChange }) => {
     selectedOrder = ORDER_TYPES[0];
   }
 
-  const handleChange = (option, changeOrder = null) => {
+  const handleChange = (option, changeOrder = 'asc') => {
     const findSelected = option
       ? columns.find((c) => c.name === option.value)
       : {};

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -269,13 +269,17 @@ export default class FiltersService implements Filters.Service {
       }
       return;
     }
+  
+    // If the user hasn't explicitely ordered the data, we still apply some default sorting
+    // (which isn't shown in the UI) so the chart looks nice
+    // The sorting depends on the type of the chart and the user can still override it manually
     if (orderBy) {
       const { name } = orderBy;
       this.sql = `${this.sql} ORDER BY ${name || sqlFields.category}`;
     } else if (chartType === "line" && this.configuration?.category?.name) {
       this.sql = `${this.sql} ORDER BY ${this.configuration.category.name}`;
-    } else if (chartType === "pie" || chartType === "donut") {
-      this.sql = `${this.sql} ORDER BY x`;
+    } else if (["pie", "donut", "bar", "stacked-bar", "bar-horizontal", "stacked-bar-horizontal"].indexOf(chartType) !== -1 && this.configuration?.value?.name) {
+      this.sql = `${this.sql} ORDER BY ${this.configuration.value.name}`;
     }
   }
 

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -33,7 +33,6 @@ export default class FiltersService implements Filters.Service {
     this.prepareFilters();
     this.prepareGroupBy();
     this.prepareOrderBy();
-    this.prepareOrder();
     this.prepareLimit();
   }
 
@@ -285,24 +284,7 @@ export default class FiltersService implements Filters.Service {
     }
 
     if (orderByField) {
-      this.sql = `${this.sql} ORDER BY ${orderByField}`;
-    }
-  }
-
-  prepareOrder() {
-    const { orderBy, chartType, aggregateFunction } = this.configuration;
-    
-    if (orderBy) {
-      const { orderType } = orderBy;
-      this.sql = `${this.sql} ${orderType ? orderType : "asc"}`;
-    } else if (
-      chartType === "pie" ||
-      chartType === "donut" ||
-      chartType === "line"
-    ) {
-      this.sql = `${this.sql} desc`;
-    } else if (aggregateFunction) {
-      this.sql = `${this.sql} desc`;
+      this.sql = `${this.sql} ORDER BY ${orderByField} ${orderBy?.orderType || 'desc'}`;
     }
   }
 

--- a/src/packages/types/src/filters.ts
+++ b/src/packages/types/src/filters.ts
@@ -6,7 +6,6 @@ export interface Service {
   prepareFilters(): void;
   prepareGroupBy(): void;
   prepareOrderBy(): void;
-  prepareOrder(): void;
   prepareLimit(): void;
   requestWidgetData(): Promise<Generic.ObjectPayload>;
 }


### PR DESCRIPTION
This PR fixes issues where some widgets wouldn't be displayed like they were in v1 because the ORDER BY statement of the SQL query wouldn't use the same logic.

## Testing instructions

There are several issues to test for. Below you can find 4 different cases.

### Bug in sorting logic

Take this widget as an example: `9d1d5e1a-794d-4fef-9e79-d52964a5a714`. You can find it [there on RW](https://preproduction.resourcewatch.org/data/explore/Cities-with-Bus-Rapid-Transit?section=Discover&zoom=3&lat=0&lng=0&pitch=0&bearing=0&basemap=dark&labels=light&layers=%255B%257B%2522dataset%2522%253A%25227614bdfe-9870-458c-9e56-dc9e83df8f79%2522%252C%2522opacity%2522%253A1%252C%2522layer%2522%253A%2522f0afc2e5-239a-4c24-ba7d-10481562ed42%2522%257D%255D&page=1&sort=most-viewed&sortDirection=-1).

With the fix, the dates should be sorted ascending.

### Sorting and aggregating

Take the same example from above, and order by “count” in the UI.

Check the “Network” panel of your browser and make sure the ORDER BY statement is `ORDER BY y asc`. It's important we use the `y` alias as the API doesn't support functions for the ORDER BY statement.

### Default sorting

Take this widget as an example (coming from FA): `5a929bd2-8aeb-491d-8814-05d6f9519534`.

Though the widget doesn't contain any sorting instructions, you should see the bars going from higher to lower as the default sorting should be on the value field and descending.

### Changing the sorting field

Using any of the examples above, change the sorting field in the UI. The data should be sorted ascending. Make sure it is the case.

## Pivotal Tracker

There are 3 tasks related to this problem:
- [Task 1](https://www.pivotaltracker.com/story/show/173176154)
- [Task 2](https://www.pivotaltracker.com/story/show/172822440)
- [Task 3](https://www.pivotaltracker.com/story/show/173195295)