### PR TITLE
Feat/error-codes

### DIFF
--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -6,6 +6,7 @@ import { localOnChangeState } from "exposed-hooks";
 
 import {
   FiltersService,
+  DataService,
   constants,
   VegaService,
   StateProxy,
@@ -132,9 +133,7 @@ function* updateWidget() {
     const fullState = yield select();
     const widgetData = yield call(getWidgetData, fullState.widgetEditor);
 
-    if (widgetData) {
-      yield put(setEditor({ widgetData: widgetData.data }));
-    }
+    yield DataService.sagasHandleSetWidgetData(widgetData.data, setEditor);
   }
 
   if (
@@ -185,9 +184,7 @@ function* updateWidgetData() {
       widgetData = yield call(getWidgetData, widgetEditor);
     }
 
-    if (widgetData) {
-      yield put(setEditor({ widgetData: widgetData.data }));
-    }
+    yield DataService.sagasHandleSetWidgetData(widgetData.data, setEditor);
 
     yield call(updateWidget);
   } 

--- a/src/packages/core/src/constants.ts
+++ b/src/packages/core/src/constants.ts
@@ -1,5 +1,11 @@
 export const APP_NAMESPACE: string = "widgetEditor";
 
+export const ERROR_CODES = {
+  DATA_UNAVAILABLE: 'WIDGET_DATA_UNAVAILABLE',
+  COLUMNS_NOT_SET: 'WIDGET_COLUMNS_NOT_SET',
+  STANDALONE_DATA_UNAVAILABLE: 'STANDALONE_DATA_UNAVAILABLE'
+}
+
 export const ALLOWED_FIELD_TYPES = [
   // --- NUMBER ----
   { name: "esriFieldTypeSmallInteger", type: "number", provider: "esri" },
@@ -69,6 +75,7 @@ export const MONTHS = [
 export default {
   MONTHS,
   APP_NAMESPACE,
+  ERROR_CODES,
   sagaEvents,
   reduxActions,
 };

--- a/src/packages/core/src/utils.ts
+++ b/src/packages/core/src/utils.ts
@@ -1,3 +1,5 @@
+import { Generic } from "@widget-editor/types";
+
 import { MONTHS } from "./constants";
 
 export const parseDate = (date: any) => {
@@ -15,7 +17,7 @@ export const isDate = (date: any) => {
   return typeof date === 'number' || !isNaN(Date.parse(date))
 }
 
-export const parseData = (data: any) => {
+export const parseData = (data: Generic.ObjectPayload) => {
   return data
     ? data.map((d: any) => {
         if (isDate(d.x)) {
@@ -25,3 +27,7 @@ export const parseData = (data: any) => {
       })
     : [];
 };
+
+export const emptyDataset = (data: Generic.ObjectPayload) => {
+  return (!data || !Array.isArray(data)) || Array.isArray(data) && data.length === 0;
+}

--- a/src/packages/types/src/generic.ts
+++ b/src/packages/types/src/generic.ts
@@ -1,2 +1,3 @@
 export type ObjectPayload = object[];
-export type Dispatcher = (object) => void;
+export type Dispatcher = (payload: ObjectPayload) => void;
+export type Action = (payload: ObjectPayload) => void;


### PR DESCRIPTION
This pr creates a useful error code template for catching: 

1. No widget data is available
2. No Value/Category is set

These will be set under `editor->errors`. And our renderer will catch these errors and show a useful message if any of them are true. 

This will only be for non standalone renderer (widget editor itself), as we will assume that any saved widget will have a useful result saved. 

The logic for handling these errors will be written inside `@core/DataService`. Two functions will be exposed, one static generator function we can use within the sagas, then one that will be used in the DataService instance itself. 