### PR TITLE
Fix bug related to empty value filter

### DIFF
--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -64,13 +64,11 @@ export default class FiltersService implements Filters.Service {
   prepareSelectStatement() {
     const { category, value } = this.configuration;
 
-    this.sql = `SELECT ${category.name} as ${
-      sqlFields.value
-    } ${this.prepareColor()}`;
+    this.sql = `SELECT ${category.name} as ${sqlFields.value
+      } ${this.prepareColor()}`;
 
-    this.sql = `${this.sql}, ${this.resolveAggregate(value.name)} as ${
-      sqlFields.category
-    } FROM ${this.resolveTableName()}`;
+    this.sql = `${this.sql}, ${this.resolveAggregate(value.name)} as ${sqlFields.category
+      } FROM ${this.resolveTableName()}`;
   }
 
   private escapeValue(value, dataType) {
@@ -124,6 +122,14 @@ export default class FiltersService implements Filters.Service {
     dataType: string
   ): string {
     let out = sql;
+
+    // If the user hasn't selected a value yet, we don't want the filter but we can't return an
+    // empty string either because if the filter is not the first we would get something like:
+    // SELECT * FROM XXX WHERE otherFilter = YYY AND LIMIT 50
+    // Instead, we can use the condition 1 = 1 which is always true
+    if (values === undefined || values === null) {
+      return `${out} 1 = 1`;
+    }
 
     if (Array.isArray(values)) {
       return `${out} ${column} IN (${values
@@ -250,8 +256,8 @@ export default class FiltersService implements Filters.Service {
       this.sql = `${this.sql} GROUP BY ${name || sqlFields.value}`;
     } else if (
       (chartType === "pie" ||
-      chartType === "donut" ||
-      chartType === "line") && aggregateFunction !== null
+        chartType === "donut" ||
+        chartType === "line") && aggregateFunction !== null
     ) {
       this.sql = `${this.sql} GROUP BY ${sqlFields.value}`;
     }
@@ -266,7 +272,7 @@ export default class FiltersService implements Filters.Service {
     let orderByField;
     if (orderBy) {
       const { name } = orderBy;
-      orderByField= name || sqlFields.category;
+      orderByField = name || sqlFields.category;
     } else if (chartType === "line" && this.configuration?.category?.name) {
       orderByField = this.configuration.category.name;
     } else if (["pie", "donut", "bar", "stacked-bar", "bar-horizontal", "stacked-bar-horizontal"].indexOf(chartType) !== -1 && this.configuration?.value?.name) {
@@ -337,7 +343,7 @@ export default class FiltersService implements Filters.Service {
     };
 
     await asyncForEach(filters, async (filter, index) => {
-      const values = filter[configuredValues] || 0;
+      const values = filter[configuredValues] || undefined;
       const column = filter[configuredColumn];
       const type = filter[configuredType];
 


### PR DESCRIPTION
Some widgets that are stored in the API define a filter by value but don't actually set the value of the filter. In that specific case, the widget-editor would assign a default value of `0` (which not always makes sense, think about string columns) and this would lead to making a request that would return no result.

The fix set a default value of `undefined` and the code that generates the SQL correctly ignores those filters.

## Testing instructions

You can test the fix with this widget: `9621647c-e8e7-44f0-a680-d8e341923ac3`.

Open it with the widget-editor and make sure the widget is correctly rendered. You can also expand the “Filters” accordion and see the value of the filter is not set.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173176293).
