### PR TITLE
Fix a wrong signal definition that crashes Vega's parser

### DIFF
--- a/src/applications/renderer/src/components/column-selections/component.js
+++ b/src/applications/renderer/src/components/column-selections/component.js
@@ -87,7 +87,7 @@ const ColumnSelections = ({
           compact={compact}
           value={chartOptions.chartValue}
           onChange={handleChangeValue}
-          getOptionLabel={(option) => resolveLabel(xTitle, option)}
+          getOptionLabel={(option) => resolveLabel(yTitle, option)}
           getOptionValue={(option) => option.identifier}
           options={columns}
           configuration={configuration}
@@ -107,7 +107,7 @@ const ColumnSelections = ({
               placeholder="Category"
               value={chartOptions.chartCategory}
               onChange={handleChangeCategory}
-              getOptionLabel={(option) => resolveLabel(yTitle, option)}
+              getOptionLabel={(option) => resolveLabel(xTitle, option)}
               getOptionValue={(option) => option.identifier}
               options={columns}
               configuration={configuration}
@@ -123,7 +123,7 @@ const ColumnSelections = ({
               placeholder="Value"
               value={chartOptions.chartValue}
               onChange={handleChangeValue}
-              getOptionLabel={(option) => resolveLabel(xTitle, option)}
+              getOptionLabel={(option) => resolveLabel(yTitle, option)}
               getOptionValue={(option) => option.identifier}
               options={columns}
               configuration={configuration}
@@ -136,7 +136,7 @@ const ColumnSelections = ({
 
           {/* -- Horizontal select column */}
 
-          {chartType !== "pie" && !reverse && (
+          {!reverse && (
             <Select
               align="horizontal"
               compact={compact}
@@ -144,7 +144,7 @@ const ColumnSelections = ({
               placeholder="Value"
               value={chartOptions.chartValue}
               onChange={handleChangeValue}
-              getOptionLabel={(option) => resolveLabel(xTitle, option)}
+              getOptionLabel={(option) => resolveLabel(yTitle, option)}
               getOptionValue={(option) => option.identifier}
               options={columns}
               configuration={configuration}
@@ -153,7 +153,7 @@ const ColumnSelections = ({
             />
           )}
 
-          {chartType !== "pie" && reverse && (
+          {reverse && (
             <Select
               align="horizontal"
               compact={compact}
@@ -161,7 +161,7 @@ const ColumnSelections = ({
               placeholder="Category"
               value={chartOptions.chartCategory}
               onChange={handleChangeCategory}
-              getOptionLabel={(option) => resolveLabel(yTitle, option)}
+              getOptionLabel={(option) => resolveLabel(xTitle, option)}
               getOptionValue={(option) => option.identifier}
               options={columns}
               configuration={configuration}

--- a/src/applications/widget-editor/src/components/widget-info/component.js
+++ b/src/applications/widget-editor/src/components/widget-info/component.js
@@ -175,23 +175,23 @@ class WidgetInfo extends React.Component {
         {!isMap && (
           <FlexContainer row={true}>
             <InputGroup>
-              <FormLabel htmlFor="options-x-axis">Value</FormLabel>
+              <FormLabel htmlFor="options-y-axis">Value</FormLabel>
               <Input
                 type="text"
-                placeholder="Overwrite axis name"
-                name="options-x-axis"
-                value={xAxisTitle}
-                onChange={(e) => this.setXAxis(e.target.value)}
-              />
-            </InputGroup>
-            <InputGroup>
-              <FormLabel htmlFor="options-y-axis">Category</FormLabel>
-              <Input
-                type="text"
-                placeholder="Overwrite axis name"
+                placeholder="Overwrite value axis name"
                 name="options-y-axis"
                 value={yAxisTitle}
                 onChange={(e) => this.setYAxis(e.target.value)}
+              />
+            </InputGroup>
+            <InputGroup>
+              <FormLabel htmlFor="options-x-axis">Category</FormLabel>
+              <Input
+                type="text"
+                placeholder="Overwrite category axis name"
+                name="options-x-axis"
+                value={xAxisTitle}
+                onChange={(e) => this.setXAxis(e.target.value)}
               />
             </InputGroup>
           </FlexContainer>

--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -80,6 +80,7 @@ function* preloadData() {
         },
         widgetData,
         configuration,
+        editor,
         theme
       );
 
@@ -153,6 +154,7 @@ function* updateWidget() {
         },
         widgetData,
         configuration,
+        editor,
         theme
       );
       yield put(setWidget(vega.getChart()));

--- a/src/packages/core/src/charts/bars-horizontal.ts
+++ b/src/packages/core/src/charts/bars-horizontal.ts
@@ -170,9 +170,9 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
   }
 
   interactionConfig() {
-    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+    const categoryProperty = this.resolveName('x');
 
-    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    let valueProperty = this.resolveName('y');
     if (this.configuration.aggregateFunction) {
       valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
     }
@@ -219,8 +219,8 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
       },
       {
         values: {
-          xCol: this.getFieldPrettyName(this.configuration.value?.name),
-          yCol: this.getFieldPrettyName(this.configuration.category?.name),
+          xCol: this.resolveName('x'),
+          yCol: this.resolveName('y'),
         },
         name: "properties",
       },

--- a/src/packages/core/src/charts/bars-horizontal.ts
+++ b/src/packages/core/src/charts/bars-horizontal.ts
@@ -6,6 +6,8 @@ import ParseSignals from './parse-signals';
 import { sqlFields } from "../helpers/wiget-helper/constants";
 
 export default class BarsHorizontal extends ChartsCommon implements Charts.Bars {
+  configuration: any;
+  editor: any;
   schema: Vega.Schema;
   widgetConfig: Widget.Payload;
   widgetData: Generic.ObjectPayload;
@@ -13,13 +15,17 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
   colorApplied: boolean;
 
   constructor(
+    configuration: any,
+    editor: any,
     schema: Vega.Schema,
     widgetConfig: Widget.Payload,
     widgetData: Generic.ObjectPayload,
     scheme: any,
     colorApplied: boolean
   ) {
-    super(widgetConfig, widgetData);
+    super(configuration, editor, widgetData);
+    this.configuration = configuration;
+    this.editor = editor;
     this.schema = schema;
     this.widgetConfig = widgetConfig;
     this.widgetData = widgetData;
@@ -164,6 +170,13 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
   }
 
   interactionConfig() {
+    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+
+    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    if (this.configuration.aggregateFunction) {
+      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
+    }
+
     return [
       {
         name: "tooltip",
@@ -171,16 +184,14 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
           fields: [
             {
               column: "y",
-              property: this.widgetConfig?.paramsConfig?.value.alias
-                || this.widgetConfig?.paramsConfig?.value.name,
+              property: valueProperty,
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "x",
-              property: this.widgetConfig?.paramsConfig?.category.alias
-                || this.widgetConfig?.paramsConfig?.category.name,
-              type: this.widgetConfig?.paramsConfig?.category?.type || 'string',
+              property: categoryProperty,
+              type: this.configuration.category?.type || 'string',
               format: this.resolveFormat('x'),
             },
           ],
@@ -190,11 +201,9 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
   }
 
   bindData(): Vega.Data[] {
-    const { widgetData, widgetConfig } = this;
-
     return [
       {
-        values: widgetData,
+        values: this.widgetData,
         name: "table",
         ...(this.isDate() ? {
           format: {
@@ -210,8 +219,8 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
       },
       {
         values: {
-          xCol: widgetConfig?.paramsConfig?.value?.alias,
-          yCol: widgetConfig?.paramsConfig?.category?.alias,
+          xCol: this.getFieldPrettyName(this.configuration.value?.name),
+          yCol: this.getFieldPrettyName(this.configuration.category?.name),
         },
         name: "properties",
       },

--- a/src/packages/core/src/charts/bars-horizontal.ts
+++ b/src/packages/core/src/charts/bars-horizontal.ts
@@ -170,13 +170,6 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
   }
 
   interactionConfig() {
-    const categoryProperty = this.resolveName('x');
-
-    let valueProperty = this.resolveName('y');
-    if (this.configuration.aggregateFunction) {
-      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
-    }
-
     return [
       {
         name: "tooltip",
@@ -184,13 +177,13 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
           fields: [
             {
               column: "y",
-              property: valueProperty,
+              property: this.resolveName('y'),
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "x",
-              property: categoryProperty,
+              property: this.resolveName('x'),
               type: this.configuration.category?.type || 'string',
               format: this.resolveFormat('x'),
             },

--- a/src/packages/core/src/charts/bars-stacked.ts
+++ b/src/packages/core/src/charts/bars-stacked.ts
@@ -130,9 +130,9 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
   }
 
   interactionConfig() {
-    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+    const categoryProperty = this.resolveName('x');
 
-    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    let valueProperty = this.resolveName('y');
     if (this.configuration.aggregateFunction) {
       valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
     }

--- a/src/packages/core/src/charts/bars-stacked.ts
+++ b/src/packages/core/src/charts/bars-stacked.ts
@@ -6,6 +6,8 @@ import ParseSignals from './parse-signals';
 import { sqlFields } from "../helpers/wiget-helper/constants";
 
 export default class BarsStacked extends ChartsCommon implements Charts.Bars {
+  configuration: any;
+  editor: any;
   schema: any;
   widgetConfig: any;
   widgetData: Generic.ObjectPayload;
@@ -13,13 +15,17 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
   scheme: any;
 
   constructor(
+    configuration: any,
+    editor: any,
     schema: any,
     widgetConfig: any,
     widgetData: Generic.ObjectPayload,
     scheme: any,
     colorApplied: boolean
   ) {
-    super(widgetConfig, widgetData);
+    super(configuration, editor, widgetData);
+    this.configuration = configuration;
+    this.editor = editor;
     this.schema = schema;
     this.widgetConfig = widgetConfig;
     this.widgetData = widgetData;
@@ -124,6 +130,13 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
   }
 
   interactionConfig() {
+    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+
+    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    if (this.configuration.aggregateFunction) {
+      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
+    }
+
     return [
       {
         name: "tooltip",
@@ -131,16 +144,14 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
           fields: [
             {
               column: "y",
-              property: this.widgetConfig?.paramsConfig?.value.alias
-                || this.widgetConfig?.paramsConfig?.value.name,
+              property: valueProperty,
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "x",
-              property: this.widgetConfig?.paramsConfig?.category.alias
-                || this.widgetConfig?.paramsConfig?.category.name,
-              type: this.widgetConfig?.paramsConfig?.category?.type || 'string',
+              property: categoryProperty,
+              type: this.configuration.category?.type || 'string',
               format: this.resolveFormat('x'),
             },
           ],

--- a/src/packages/core/src/charts/bars-stacked.ts
+++ b/src/packages/core/src/charts/bars-stacked.ts
@@ -130,13 +130,6 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
   }
 
   interactionConfig() {
-    const categoryProperty = this.resolveName('x');
-
-    let valueProperty = this.resolveName('y');
-    if (this.configuration.aggregateFunction) {
-      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
-    }
-
     return [
       {
         name: "tooltip",
@@ -144,13 +137,13 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
           fields: [
             {
               column: "y",
-              property: valueProperty,
+              property: this.resolveName('y'),
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "x",
-              property: categoryProperty,
+              property: this.resolveName('x'),
               type: this.configuration.category?.type || 'string',
               format: this.resolveFormat('x'),
             },

--- a/src/packages/core/src/charts/bars.ts
+++ b/src/packages/core/src/charts/bars.ts
@@ -6,6 +6,8 @@ import ParseSignals from './parse-signals';
 import { sqlFields } from "../helpers/wiget-helper/constants";
 
 export default class Bars extends ChartsCommon implements Charts.Bars {
+  configuration: any;
+  editor: any;
   schema: any;
   widgetConfig: any;
   widgetData: Generic.ObjectPayload;
@@ -13,13 +15,17 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
   scheme: any;
 
   constructor(
+    configuration: any,
+    editor: any,
     schema: any,
     widgetConfig: any,
     widgetData: Generic.ObjectPayload,
     scheme: any,
     colorApplied: boolean
   ) {
-    super(widgetConfig, widgetData);
+    super(configuration, editor, widgetData);
+    this.configuration = configuration;
+    this.editor = editor;
     this.schema = schema;
     this.widgetConfig = widgetConfig;
     this.widgetData = widgetData;
@@ -124,6 +130,13 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
   }
 
   interactionConfig() {
+    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+
+    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    if (this.configuration.aggregateFunction) {
+      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
+    }
+
     return [
       {
         name: "tooltip",
@@ -131,16 +144,14 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
           fields: [
             {
               column: "y",
-              property: this.widgetConfig?.paramsConfig?.value.alias
-                || this.widgetConfig?.paramsConfig?.value.name,
+              property: valueProperty,
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "x",
-              property: this.widgetConfig?.paramsConfig?.category.alias
-                || this.widgetConfig?.paramsConfig?.category.name,
-              type: this.widgetConfig?.paramsConfig?.category?.type || 'string',
+              property: categoryProperty,
+              type: this.configuration.category?.type || 'string',
               format: this.resolveFormat('x'),
             },
           ],

--- a/src/packages/core/src/charts/bars.ts
+++ b/src/packages/core/src/charts/bars.ts
@@ -130,13 +130,6 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
   }
 
   interactionConfig() {
-    const categoryProperty = this.resolveName('x');
-
-    let valueProperty = this.resolveName('y');
-    if (this.configuration.aggregateFunction) {
-      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
-    }
-
     return [
       {
         name: "tooltip",
@@ -144,13 +137,13 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
           fields: [
             {
               column: "y",
-              property: valueProperty,
+              property: this.resolveName('y'),
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "x",
-              property: categoryProperty,
+              property: this.resolveName('x'),
               type: this.configuration.category?.type || 'string',
               format: this.resolveFormat('x'),
             },

--- a/src/packages/core/src/charts/bars.ts
+++ b/src/packages/core/src/charts/bars.ts
@@ -130,9 +130,9 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
   }
 
   interactionConfig() {
-    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+    const categoryProperty = this.resolveName('x');
 
-    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    let valueProperty = this.resolveName('y');
     if (this.configuration.aggregateFunction) {
       valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
     }

--- a/src/packages/core/src/charts/chart-common.ts
+++ b/src/packages/core/src/charts/chart-common.ts
@@ -16,8 +16,20 @@ export default class ChartCommon {
     return this.configuration.category?.type === 'date';
   }
 
-  getFieldPrettyName(fieldName) {
+  resolveName(axis: 'x' | 'y') {
+    const { xAxisTitle, yAxisTitle } = this.configuration;
+
+    if (axis === 'x' && xAxisTitle) {
+      return xAxisTitle;
+    }
+
+    if (axis === 'y' && yAxisTitle) {
+      return yAxisTitle;
+    }
+
+    const fieldName = this.configuration[axis === 'x' ? 'category' : 'value']?.name;
     const field = this.editor.fields?.find(f => f.columnName === fieldName);
+
     return field?.metadata?.alias
       ? field.metadata.alias
       : fieldName;

--- a/src/packages/core/src/charts/chart-common.ts
+++ b/src/packages/core/src/charts/chart-common.ts
@@ -1,27 +1,36 @@
 import { Vega, Generic } from "@widget-editor/types";
 
 export default class ChartCommon {
-  wConfig: any;
+  configuration: any;
+  editor: any;
   wData: Generic.ObjectPayload = [];
   schema: Vega.Schema;
 
-  constructor(widgetConfig: any, widgetData: Generic.ObjectPayload) {
-    this.wConfig = widgetConfig;
+  constructor(configuration: any, editor: any, widgetData: Generic.ObjectPayload) {
+    this.configuration = configuration;
+    this.editor = editor;
     this.wData = widgetData || [];
   }
 
   isDate() {
-    return this.wConfig?.paramsConfig?.category?.type === 'date';
+    return this.configuration.category?.type === 'date';
+  }
+
+  getFieldPrettyName(fieldName) {
+    const field = this.editor.fields?.find(f => f.columnName === fieldName);
+    return field?.metadata?.alias
+      ? field.metadata.alias
+      : fieldName;
   }
 
   resolveFormat(axis: 'x' | 'y') {
     // The Y axis is 100% determined by the format the user choose in the UI
     if (axis === 'y') {
-      return this.wConfig?.paramsConfig?.format || 's';
+      return this.configuration.format || 's';
     }
 
     // The X axis' format depends on the type of the column
-    if (this.wConfig?.paramsConfig?.category?.type === 'date') {
+    if (this.configuration.category?.type === 'date') {
       const timestamps = this.wData.map((d: any) => +(new Date(d.x)));
 
       const min = Math.min(...timestamps);
@@ -46,7 +55,7 @@ export default class ChartCommon {
       }
 
       return '%Y'; // ex: 2017
-    } else if (this.wConfig?.paramsConfig?.category?.type === 'number') {
+    } else if (this.configuration.category?.type === 'number') {
       const allIntegers = this.wData.length && this.wData.every((d: any) => parseInt(d.x, 10) === d.x);
       if (allIntegers) {
         return 'd';

--- a/src/packages/core/src/charts/chart-common.ts
+++ b/src/packages/core/src/charts/chart-common.ts
@@ -30,9 +30,15 @@ export default class ChartCommon {
     const fieldName = this.configuration[axis === 'x' ? 'category' : 'value']?.name;
     const field = this.editor.fields?.find(f => f.columnName === fieldName);
 
-    return field?.metadata?.alias
+    const name = field?.metadata?.alias
       ? field.metadata.alias
       : fieldName;
+
+    if (axis === 'y' && this.configuration.aggregateFunction) {
+      return `${name} (${this.configuration.aggregateFunction})`;
+    }
+
+    return name;
   }
 
   resolveFormat(axis: 'x' | 'y') {

--- a/src/packages/core/src/charts/line.ts
+++ b/src/packages/core/src/charts/line.ts
@@ -106,9 +106,9 @@ export default class Line extends ChartsCommon implements Charts.Line {
   }
 
   interactionConfig() {
-    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+    const categoryProperty = this.resolveName('x');
 
-    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    let valueProperty = this.resolveName('y');
     if (this.configuration.aggregateFunction) {
       valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
     }

--- a/src/packages/core/src/charts/line.ts
+++ b/src/packages/core/src/charts/line.ts
@@ -6,18 +6,24 @@ import ParseSignals from './parse-signals';
 import { sqlFields } from "../helpers/wiget-helper/constants";
 
 export default class Line extends ChartsCommon implements Charts.Line {
+  configuration: any;
+  editor: any;
   schema: Vega.Schema;
   widgetConfig: Widget.Payload;
   widgetData: Generic.ObjectPayload;
   scheme: any;
 
   constructor(
+    configuration: any,
+    editor: any,
     schema: Vega.Schema,
     widgetConfig: Widget.Payload,
     widgetData: Generic.ObjectPayload,
     scheme: any
   ) {
-    super(widgetConfig, widgetData);
+    super(configuration, editor, widgetData);
+    this.configuration = configuration;
+    this.editor = editor;
     this.schema = schema;
     this.widgetConfig = widgetConfig;
     this.widgetData = widgetData;
@@ -100,6 +106,13 @@ export default class Line extends ChartsCommon implements Charts.Line {
   }
 
   interactionConfig() {
+    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+
+    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    if (this.configuration.aggregateFunction) {
+      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
+    }
+
     return [
       {
         name: "tooltip",
@@ -107,16 +120,14 @@ export default class Line extends ChartsCommon implements Charts.Line {
           fields: [
             {
               column: "y",
-              property: this.widgetConfig?.paramsConfig?.value.alias
-                || this.widgetConfig?.paramsConfig?.value.name,
+              property: valueProperty,
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "x",
-              property: this.widgetConfig?.paramsConfig?.category.alias
-                || this.widgetConfig?.paramsConfig?.category.name,
-              type: this.widgetConfig?.paramsConfig?.category?.type || 'string',
+              property: categoryProperty,
+              type: this.configuration.category?.type || 'string',
               format: this.resolveFormat('x'),
             },
           ],

--- a/src/packages/core/src/charts/line.ts
+++ b/src/packages/core/src/charts/line.ts
@@ -106,13 +106,6 @@ export default class Line extends ChartsCommon implements Charts.Line {
   }
 
   interactionConfig() {
-    const categoryProperty = this.resolveName('x');
-
-    let valueProperty = this.resolveName('y');
-    if (this.configuration.aggregateFunction) {
-      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
-    }
-
     return [
       {
         name: "tooltip",
@@ -120,13 +113,13 @@ export default class Line extends ChartsCommon implements Charts.Line {
           fields: [
             {
               column: "y",
-              property: valueProperty,
+              property: this.resolveName('y'),
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "x",
-              property: categoryProperty,
+              property: this.resolveName('x'),
               type: this.configuration.category?.type || 'string',
               format: this.resolveFormat('x'),
             },

--- a/src/packages/core/src/charts/parse-signals.ts
+++ b/src/packages/core/src/charts/parse-signals.ts
@@ -64,7 +64,18 @@ export default class ParseSignals {
     const signals = [];
     const datumFormat = this.chartType === 'line' ? 'datum.datum' : 'datum';
 
-    this.getTooltipFields().forEach(field => {
+    // When the user chooses the same field for category and value, and doesn't apply an aggregation
+    // to the value field, then the two tooltip fields (category and value) will have the same
+    // property
+    // To avoid setting twice the same signal (which would crash the editor), we remove any
+    // duplicated field
+    // Note: If the user uses twice the same field but with an aggregation on the value field, the
+    // name of the aggregation is added to its property i.e. the two fields have a unique property
+    const tooltipFields = this.getTooltipFields();
+    const uniqueTooltipFields = tooltipFields
+      .filter((field, index) => tooltipFields.findIndex(f => f.property === field.property) === index);
+
+    uniqueTooltipFields.forEach(field => {
       if (field.format && field.type === 'number') {
         signals.push(`"${field.property}": format(${datumFormat}.${this.stripDatum(field.column)}, "${field.format}")`);
       } else if (field.format && field.type === 'date') {

--- a/src/packages/core/src/charts/pie.ts
+++ b/src/packages/core/src/charts/pie.ts
@@ -70,13 +70,6 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
   }
 
   interactionConfig() {
-    const categoryProperty = this.resolveName('x');
-
-    let valueProperty = this.resolveName('y');
-    if (this.configuration.aggregateFunction) {
-      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
-    }
-
     return [
       {
         name: "tooltip",
@@ -84,13 +77,13 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
           fields: [
             {
               column: "value",
-              property: valueProperty,
+              property: this.resolveName('y'),
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "category",
-              property: categoryProperty,
+              property: this.resolveName('x'),
               type: 'string',
             },
           ],

--- a/src/packages/core/src/charts/pie.ts
+++ b/src/packages/core/src/charts/pie.ts
@@ -70,9 +70,9 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
   }
 
   interactionConfig() {
-    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+    const categoryProperty = this.resolveName('x');
 
-    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    let valueProperty = this.resolveName('y');
     if (this.configuration.aggregateFunction) {
       valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
     }

--- a/src/packages/core/src/charts/pie.ts
+++ b/src/packages/core/src/charts/pie.ts
@@ -4,18 +4,24 @@ import ChartsCommon from './chart-common';
 import ParseSignals from './parse-signals';
 
 export default class Pie extends ChartsCommon implements Charts.Pie {
+  configuration: any;
+  editor: any;
   schema: Vega.Schema;
   widgetConfig: Widget.Payload;
   widgetData: Generic.ObjectPayload;
   scheme: any;
 
   constructor(
+    configuration: any,
+    editor: any,
     schema: Vega.Schema,
     widgetConfig: Widget.Payload,
     widgetData: Generic.ObjectPayload,
     scheme: any
   ) {
-    super(widgetConfig, widgetData);
+    super(configuration, editor, widgetData);
+    this.configuration = configuration;
+    this.editor = editor;
     this.schema = schema;
     this.scheme = scheme;
     this.widgetConfig = widgetConfig;
@@ -64,6 +70,13 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
   }
 
   interactionConfig() {
+    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+
+    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    if (this.configuration.aggregateFunction) {
+      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
+    }
+
     return [
       {
         name: "tooltip",
@@ -71,15 +84,13 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
           fields: [
             {
               column: "value",
-              property: this.widgetConfig?.paramsConfig?.value.alias
-                || this.widgetConfig?.paramsConfig?.value.name,
+              property: valueProperty,
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "category",
-              property: this.widgetConfig?.paramsConfig?.category.alias
-                || this.widgetConfig?.paramsConfig?.category.name,
+              property: categoryProperty,
               type: 'string',
             },
           ],
@@ -103,12 +114,11 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
   }
 
   resolveInnerRadius() {
-    const chartType = this.widgetConfig?.paramsConfig?.chartType || "pie";
-    const radius = this.widgetConfig?.paramsConfig?.donutRadius || 100;
-    if (chartType === "pie") {
+    if (this.configuration.chartType === "pie") {
       return "0";
     }
-    return radius;
+
+    return this.configuration.donutRadius;
   }
 
   setMarks() {

--- a/src/packages/core/src/charts/scatter.ts
+++ b/src/packages/core/src/charts/scatter.ts
@@ -59,13 +59,6 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
   }
 
   interactionConfig() {
-    const categoryProperty = this.resolveName('x');
-
-    let valueProperty = this.resolveName('y');
-    if (this.configuration.aggregateFunction) {
-      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
-    }
-
     return [
       {
         name: "tooltip",
@@ -73,13 +66,13 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
           fields: [
             {
               column: "y",
-              property: valueProperty,
+              property: this.resolveName('y'),
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "x",
-              property: categoryProperty,
+              property: this.resolveName('x'),
               type: this.configuration.category?.type || 'string',
               format: this.resolveFormat('x'),
             },

--- a/src/packages/core/src/charts/scatter.ts
+++ b/src/packages/core/src/charts/scatter.ts
@@ -59,9 +59,9 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
   }
 
   interactionConfig() {
-    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+    const categoryProperty = this.resolveName('x');
 
-    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    let valueProperty = this.resolveName('y');
     if (this.configuration.aggregateFunction) {
       valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
     }

--- a/src/packages/core/src/charts/scatter.ts
+++ b/src/packages/core/src/charts/scatter.ts
@@ -6,6 +6,8 @@ import ParseSignals from './parse-signals';
 import { sqlFields } from "../helpers/wiget-helper/constants";
 
 export default class Scatter extends ChartsCommon implements Charts.Scatter {
+  configuration: any;
+  editor: any;
   schema: Vega.Schema;
   widgetConfig: Widget.Payload;
   widgetData: Generic.ObjectPayload;
@@ -13,13 +15,17 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
   scheme: any;
 
   constructor(
+    configuration: any,
+    editor: any,
     schema: Vega.Schema,
     widgetConfig: Widget.Payload,
     widgetData: Generic.ObjectPayload,
     scheme: any,
     colorApplied: boolean
   ) {
-    super(widgetConfig, widgetData);
+    super(configuration, editor, widgetData);
+    this.configuration = configuration;
+    this.editor = editor;
     this.schema = schema;
     this.widgetConfig = widgetConfig;
     this.widgetData = widgetData;
@@ -53,6 +59,13 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
   }
 
   interactionConfig() {
+    const categoryProperty = this.getFieldPrettyName(this.configuration.category?.name);
+
+    let valueProperty = this.getFieldPrettyName(this.configuration.value?.name);
+    if (this.configuration.aggregateFunction) {
+      valueProperty = `${valueProperty} (${this.configuration.aggregateFunction})`;
+    }
+
     return [
       {
         name: "tooltip",
@@ -60,16 +73,14 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
           fields: [
             {
               column: "y",
-              property: this.widgetConfig?.paramsConfig?.value.alias
-                || this.widgetConfig?.paramsConfig?.value.name,
+              property: valueProperty,
               type: "number",
               format: this.resolveFormat('y'),
             },
             {
               column: "x",
-              property: this.widgetConfig?.paramsConfig?.category.alias
-                || this.widgetConfig?.paramsConfig?.category.name,
-              type: this.widgetConfig?.paramsConfig?.category?.type || 'string',
+              property: categoryProperty,
+              type: this.configuration.category?.type || 'string',
               format: this.resolveFormat('x'),
             },
           ],

--- a/src/packages/core/src/services/vega.ts
+++ b/src/packages/core/src/services/vega.ts
@@ -42,6 +42,7 @@ export default class VegaService implements Charts.Service {
   widgetConfig: any;
   widgetData: any;
   configuration: any;
+  editor: any;
   slizeCount: number;
   scheme: any;
   schema: Vega.Schema;
@@ -51,6 +52,7 @@ export default class VegaService implements Charts.Service {
     widgetConfig: any,
     widgetData: any,
     configuration: any,
+    editor: any,
     theme: any
   ) {
     if (theme) {
@@ -67,6 +69,7 @@ export default class VegaService implements Charts.Service {
     this.widgetConfig = widgetConfig;
     this.widgetData = widgetData;
     this.configuration = configuration;
+    this.editor = editor;
 
     this.slizeCount = configuration?.slizeCount || 5;
 
@@ -173,6 +176,8 @@ export default class VegaService implements Charts.Service {
 
     if (chartType === "pie" || chartType === "donut") {
       chart = new Pie(
+        this.configuration,
+        this.editor,
         this.schema,
         this.widgetConfig,
         data,
@@ -182,6 +187,8 @@ export default class VegaService implements Charts.Service {
 
     if (chartType === "bar-horizontal") {
       chart = new BarsHorizontal(
+        this.configuration,
+        this.editor,
         this.schema,
         this.widgetConfig,
         data,
@@ -192,6 +199,8 @@ export default class VegaService implements Charts.Service {
 
     if (chartType === "bar") {
       chart = new Bars(
+        this.configuration,
+        this.editor,
         this.schema,
         this.widgetConfig,
         data,
@@ -202,6 +211,8 @@ export default class VegaService implements Charts.Service {
 
     if (chartType === "stacked-bar") {
       chart = new BarsStacked(
+        this.configuration,
+        this.editor,
         this.schema,
         this.widgetConfig,
         data,
@@ -212,6 +223,8 @@ export default class VegaService implements Charts.Service {
 
     if (chartType === "line") {
       chart = new Line(
+        this.configuration,
+        this.editor,
         this.schema,
         this.widgetConfig,
         data,
@@ -221,6 +234,8 @@ export default class VegaService implements Charts.Service {
 
     if (chartType === "scatter") {
       chart = new Scatter(
+        this.configuration,
+        this.editor,
         this.schema,
         this.widgetConfig,
         data,


### PR DESCRIPTION
Some widgets are constructed using the same field for “category” and “value”. When this happens, the code responsible to create the signals for the tooltip would create an object with twice the same key (the name of the field for the “category” and the “value”).

This PR fixes the issue using two solutions:
- If “value” doesn't have any aggregation, then we only add one signal
- If “value” has an aggregation, we add the name of the function to the “value”'s signal's key so we don't have duplicates anymore

In addition, this PR fixes an issue where the “value axis title” and the “category axis title” would be inverted in some cases.

Finally, the PR also makes sure to use the axis' title or the alias instead of the column name in the tooltip, if available.

## Testing instructions

Take this widget as an example: `0948ea75-1eb2-42d2-89c2-f4dcff93b51c`.

First of all, it should render correctly (see it uses the same column for “value” and “label”, and has an aggregation).

Now, move on to the scatter plot, pick a column of type number, and use it for the “value” and “category” fields. Remove the aggregation. The chart should render correctly and the tooltip should show only one item.

Go back to the visualization of the widget and add a “value title”. Make sure the select below the pie is showing the same title and that the tooltip also does.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173230334).
