### PR TITLE
Fix bug when generating the SQL for widgets with a “none” aggregation

### DIFF
--- a/src/applications/widget-editor/src/components/widget-info/component.js
+++ b/src/applications/widget-editor/src/components/widget-info/component.js
@@ -124,7 +124,7 @@ class WidgetInfo extends React.Component {
 
   setAggregation(agg) {
     this.setState({
-      aggregateFunction: agg.value === "NONE" ? null : agg.value,
+      aggregateFunction: agg.value,
     });
     this.handleUpdate();
   }

--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -53,6 +53,13 @@ function* preloadData() {
       ? widgetConfig.paramsConfig
       : null;
 
+    // The “none” option is equal to having no aggregation at all but might cause issues when
+    // generating the SQL query, that's why it is removed
+    // This is an old value from v1
+    if (paramsConfig?.aggregateFunction === 'none') {
+      paramsConfig.aggregateFunction = null;
+    }
+
     const configuration = {
       ...(paramsConfig ? { ...paramsConfig } : {}),
       title: name,


### PR DESCRIPTION
Old versions of v1 used to serialise the fact that a widget has no aggregation either with the value `null` or `'none'`. When the value was `'none'`, v2 would still think there is an aggregation and would generate an incorrect SQL query.

The fix simply replaces the `'none'` value with `null` when the widget is restored so the rest of the code doesn't have to perform further checks.

## Testing instructions

Restore this widget `e23ecc03-5503-48d8-a85a-233c1063ef37`. It should render correctly and the SQL shouldn't perform any aggregation on the “value” field.

## Pivotal Tracker

Not tracked. Widget reported as buggy by WRI.