### PR TITLE
Fix bugs related to the legend and the color field

### DIFF
--- a/src/applications/renderer/src/components/legend/component.js
+++ b/src/applications/renderer/src/components/legend/component.js
@@ -38,7 +38,6 @@ const Legend = ({
   activeScheme,
   columns,
   widgetData,
-  setFilters,
   patchConfiguration,
   compact,
 }) => {
@@ -51,9 +50,6 @@ const Legend = ({
     if (isPie) {
       patchConfiguration({ category: color });
     } else {
-      setFilters({
-        color,
-      });
       patchConfiguration({ color });
     }
   };

--- a/src/applications/renderer/src/components/legend/component.js
+++ b/src/applications/renderer/src/components/legend/component.js
@@ -31,7 +31,6 @@ function resolveValue(val) {
 }
 
 const Legend = ({
-  color,
   configuration,
   schemeColor,
   selectedColor,
@@ -42,7 +41,7 @@ const Legend = ({
   compact,
 }) => {
   const isPie = configuration.chartType === "pie";
-  const isSingleColorSelection = !isPie && !isObjectLike(color);
+  const isSingleColorSelection = !isPie && !isObjectLike(configuration.color);
 
   const handleChange = (option) => {
     const color = option.identifier === "___single_color" ? null : option;
@@ -59,7 +58,7 @@ const Legend = ({
       {isSingleColorSelection && (
         <StyledColorsBoxContainer
           overflowIsHidden={false}
-          alignCenter={!isObjectLike(color)}
+          alignCenter
         >
           <StyledColorsBox alignCenter={false}>
             <StyledColorDot color={schemeColor} />
@@ -72,11 +71,11 @@ const Legend = ({
           {widgetData &&
             widgetData.map((node, index) => {
               return (
-                <StyledColorsBox alignCenter={true} key={`${node.x}-${index}`}>
+                <StyledColorsBox alignCenter={true} key={`${isPie ? node.x : node.color}-${index}`}>
                   <StyledColorDot
                     color={resolveSchemeColor(activeScheme.category, index)}
                   />
-                  {resolveValue(node.x)}
+                  {resolveValue(isPie ? node.x : node.color) || '−'}
                 </StyledColorsBox>
               );
             })}

--- a/src/applications/renderer/src/components/legend/index.js
+++ b/src/applications/renderer/src/components/legend/index.js
@@ -1,6 +1,5 @@
 import { redux } from "@widget-editor/shared";
 
-import { setFilters } from "@widget-editor/shared/lib/modules/filters/actions";
 import { patchConfiguration } from "@widget-editor/shared/lib/modules/configuration/actions";
 
 // Components
@@ -21,5 +20,5 @@ export default redux.connectState(
     widgetData:
       state.widget && state.widget.data ? state.widget.data[0].values : null,
   }),
-  { setFilters, patchConfiguration }
+  { patchConfiguration }
 )(ChartColorFilter);

--- a/src/applications/renderer/src/components/legend/index.js
+++ b/src/applications/renderer/src/components/legend/index.js
@@ -11,7 +11,6 @@ import * as themeSelectors from "@widget-editor/shared/lib/modules/theme/selecto
 export default redux.connectState(
   (state) => ({
     widget: state.widget,
-    color: state.filters.color,
     configuration: state.configuration,
     selectedColor: widgetSelectors.getSelectedColor(state),
     columns: widgetSelectors.getWidgetColumns(state, { colorDimention: true }),

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -46,7 +46,7 @@ export default class FiltersService implements Filters.Service {
   prepareColor() {
     const { color } = this.configuration;
     if (isPlainObject(color)) {
-      return `, ${color.identifier} as color`;
+      return `, ${color.name} as color`;
     }
     return "";
   }

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -244,22 +244,23 @@ export default class FiltersService implements Filters.Service {
   }
 
   prepareGroupBy() {
-    const { groupBy, aggregateFunction, chartType } = this.configuration;
+    const { groupBy, aggregateFunction, chartType, color } = this.configuration;
 
     if (!!aggregateFunction) {
       this.sql = `${this.sql} GROUP BY x`;
+
+      // If the user has filled the color field, we also need to group by it only and only if
+      // there's also an aggregation (source: v1)
+      if (color?.name) {
+        this.sql = `${this.sql}, color`;
+      }
+
       return;
     }
 
     if (groupBy) {
       const { name } = groupBy;
       this.sql = `${this.sql} GROUP BY ${name || sqlFields.value}`;
-    } else if (
-      (chartType === "pie" ||
-        chartType === "donut" ||
-        chartType === "line") && aggregateFunction !== null
-    ) {
-      this.sql = `${this.sql} GROUP BY ${sqlFields.value}`;
     }
   }
 

--- a/src/packages/shared/src/modules/widget/selectors.js
+++ b/src/packages/shared/src/modules/widget/selectors.js
@@ -51,26 +51,6 @@ export const getWidgetSelectedColumn = createSelector(
   }
 );
 
-export const getSelectedColor = createSelector(
-  [getConfiguration, getDataset, getFilters],
-  (configuration, dataset, filters) => {
-    if (
-      !dataset ||
-      !dataset.id ||
-      !dataset.attributes ||
-      !dataset.attributes.metadata
-    ) {
-      return null;
-    }
-
-    if (configuration.chartType === "pie") {
-      return configuration.category || null;
-    }
-
-    return filters.color || SINGLE_COLOR_OPTION;
-  }
-);
-
 export const getWidgetColumns = createSelector(
   [getConfiguration, getDataset, getFields, getProps],
   (configuration, dataset, fields, props) => {
@@ -111,5 +91,29 @@ export const getWidgetColumns = createSelector(
     }
 
     return columns;
+  }
+);
+
+export const getSelectedColor = createSelector(
+  [getConfiguration, getDataset, getWidgetColumns],
+  (configuration, dataset, widgetColumns) => {
+    if (
+      !dataset ||
+      !dataset.id ||
+      !dataset.attributes ||
+      !dataset.attributes.metadata
+    ) {
+      return null;
+    }
+
+    if (configuration.chartType === "pie") {
+      return configuration.category || null;
+    }
+
+    const colorColumn = configuration.color?.name
+      ? widgetColumns.find(column => column.identifier === configuration.color.name)
+      : null;
+
+    return  colorColumn || SINGLE_COLOR_OPTION;
   }
 );

--- a/src/packages/shared/src/modules/widget/selectors.js
+++ b/src/packages/shared/src/modules/widget/selectors.js
@@ -107,7 +107,11 @@ export const getSelectedColor = createSelector(
     }
 
     if (configuration.chartType === "pie") {
-      return configuration.category || null;
+      const colorColumn = configuration.category?.name
+        ? widgetColumns.find(column => column.identifier === configuration.category.name)
+        : null;
+
+      return colorColumn || null;
     }
 
     const colorColumn = configuration.color?.name


### PR DESCRIPTION
This PR fixes a bunch of bugs related to the legend and the color field:
- Widgets with a color field wouldn't render
- Color field wouldn't be restored for widgets with color field
- SQL generation would differ from v1 for widgets with color field
- Legend would display wrong information when the user would fill the color field
- Category field wouldn't fill correctly for pie charts when switching from a widget with color field

## Testing instructions

Here are tests for all of the cases above.

### Widgets with a color field wouldn't render

1. Open `2fb72c41-2f6c-43a2-be69-7235c6ccba2c`

Make sure the widget is rendering correctly.

### Color field wouldn't be restored for widgets with color field

1. Open `2fb72c41-2f6c-43a2-be69-7235c6ccba2c`

Make sure the color field contains “Country”.

### SQL generation would differ from v1 for widgets with color field

1. Open the “Network” tab of your browser's dev tools
2. Open `2fb72c41-2f6c-43a2-be69-7235c6ccba2c`

Search for the SQL query, make sure the GROUP BY statement contains both `x` and `color`.

### Legend would display wrong information when the user would fill the color field

1. Open `2fb72c41-2f6c-43a2-be69-7235c6ccba2c`
2. Select the “Dam Name” option in the color field

Make sure the legend is updated and displays something different from the countries.

### Category field wouldn't fill correctly for pie charts when switching from a widget with color field

1. Open `2fb72c41-2f6c-43a2-be69-7235c6ccba2c`
2. Change the chart visualisation to pie

Make sure the category field (which replaces the color one) still displays “Country”.

## Pivotal Tracker

Most of the issues are not tracked, but [one of them is](https://www.pivotaltracker.com/story/show/173265839).
