### PR TITLE
Fix bug causing min hight being ignored on embeded maps

### DIFF
--- a/src/packages/map/src/styles.js
+++ b/src/packages/map/src/styles.js
@@ -4,7 +4,7 @@ export const StyledMapContainer = styled.div`
   display: flex;
   height: 100%;
   width: 100%;
-  min-height: 380px;
+  min-height: inherit;
   .map-leaflet {
     z-index: 1;
     display: flex;


### PR DESCRIPTION
Before we had a fixed min height, this wont work as embedded maps are dynamic, and what happens is that the bbox focus is off as the map extends its parent. This pr makes sure the map takes the parent width/height no matter the definitions. 

## Testing instructions

Embedded maps should not have a fixed height when embedded and adapt to its parent.  Check any map widget and click the "renderer" button. 

## Pivotal Tracker

https://www.pivotaltracker.com/n/projects/2154258/stories/173151529
