### PR TITLE
Prevent a Vega bug from affecting future widgets

### DIFF
--- a/src/applications/renderer/src/components/standalone/component.js
+++ b/src/applications/renderer/src/components/standalone/component.js
@@ -28,7 +28,6 @@ const Standalone = ({ thumbnail, widgetConfig }) => {
   wConfig.autosize = {
     type: "fit",
     contains: "padding",
-    resize: true,
   };
 
   wConfig.width = wConfig.width || 400;

--- a/src/packages/core/src/charts/bars-horizontal.ts
+++ b/src/packages/core/src/charts/bars-horizontal.ts
@@ -120,6 +120,10 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
         grid: false,
         labelOverlap: "parity",
         labelAlign: "right",
+        // titleLimit is necessary so the title of the axis fits the viewport
+        // If it doesn't the chart might not be displayed at all due to this bug:
+        // https://github.com/vega/vega/issues/1350
+        titleLimit: { "signal": "height" },
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/bars-stacked.ts
+++ b/src/packages/core/src/charts/bars-stacked.ts
@@ -192,6 +192,10 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
         scale: "y",
         labelOverlap: "parity",
         format: this.resolveFormat('y'),
+        // titleLimit is necessary so the title of the axis fits the viewport
+        // If it doesn't the chart might not be displayed at all due to this bug:
+        // https://github.com/vega/vega/issues/1350
+        titleLimit: { "signal": "height" },
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/bars.ts
+++ b/src/packages/core/src/charts/bars.ts
@@ -192,6 +192,10 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
         scale: "y",
         labelOverlap: "parity",
         format: this.resolveFormat('y'),
+        // titleLimit is necessary so the title of the axis fits the viewport
+        // If it doesn't the chart might not be displayed at all due to this bug:
+        // https://github.com/vega/vega/issues/1350
+        titleLimit: { "signal": "height" },
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/line.ts
+++ b/src/packages/core/src/charts/line.ts
@@ -235,6 +235,10 @@ export default class Line extends ChartsCommon implements Charts.Line {
         scale: "y",
         labelOverlap: "parity",
         format: this.resolveFormat('y'),
+        // titleLimit is necessary so the title of the axis fits the viewport
+        // If it doesn't the chart might not be displayed at all due to this bug:
+        // https://github.com/vega/vega/issues/1350
+        titleLimit: { "signal": "height" },
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/scatter.ts
+++ b/src/packages/core/src/charts/scatter.ts
@@ -209,6 +209,10 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
         "labelOverlap": "parity",
         "orient": "left",
         format: this.resolveFormat('y'),
+        // titleLimit is necessary so the title of the axis fits the viewport
+        // If it doesn't the chart might not be displayed at all due to this bug:
+        // https://github.com/vega/vega/issues/1350
+        titleLimit: { "signal": "height" },
       }
     ]
   }


### PR DESCRIPTION
All Vega versions suffer a [bug](https://github.com/vega/vega/issues/1350) which makes the chart disappear if one of its element is bigger than the viewport and the visualisation is using `autosize`'s `fit` property.

The suggested fix from the Vega team is to limit the size of the overflowing element meanwhile an official fix is provided.

Currently, the only case where the issue has arisen is when the Y axis' title is quite long and the widget quite flat. The solution this PR brings is to add a `titleLimit` property to the Y axis of all the charts with the value `{ signal: 'height' }` so that the title has an ellipsis if it's longer than the height of the viewport.

It's important to note that this solution will only apply to new widgets or widgets saved with the widget-editor after the fix. The widgets that already exist will have to be migrated ([task](https://www.pivotaltracker.com/story/show/173306949)).

On a side note, this PR also remove `autosize`'s `resize` property as it is not needed (the renderer takes care of re-rendering the chart if the window's size changes) and as it re-renders the chart on every interaction (hover for example).

## Testing instructions

To replicate the fix:
1. Restore this widget: `ce90c151-f70a-48e3-92f1-6b62c1436a4c`
2. Before [this line](https://github.com/Vizzuality/widget-editor/blob/63e03a677845bea4c8b2b66cb8eafc04e514f17f/src/applications/renderer/src/components/chart/component.js#L146), add the following:
```js
conf.axes[1].titleLimit = { signal: 'height' };
```
3. Open the playground and click on the “View renderer” button

Make sure the widget is correctly rendered.

4. Change the size of your browser's window several times

Make sure the widget is re-rendered as the size of the window changes and that the widget never collapses on itself (height 0).

## Pivotal Tracker

Not tracked, but reported by the RW team.
