### PR TITLE
Fix crashes related to the logic of gathering the fields of the dataset

### DIFF
--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -50,17 +50,17 @@ export default class DataService {
   }
 
   async restoreEditor(datasetId, widgetId) {
-    this.setEditor({ 
+    this.setEditor({
       restoring: true
     });
-    
+
     this.widgetId = widgetId;
     this.adapter.setDatasetId(datasetId);
 
     await this.getDatasetAndWidgets();
     await this.getFieldsAndLayers();
     const filters = await this.handleFilters(true);
-    
+
     if (
       this.widget.attributes?.widgetConfig?.paramsConfig &&
       this.widget.attributes?.widgetConfig?.value &&
@@ -75,7 +75,7 @@ export default class DataService {
 
   async handleFilters(restore: boolean = false) {
     if (!this.widget) return null;
-    
+
     const paramsConfig = this.widget.attributes?.widgetConfig?.paramsConfig;
     const filters = paramsConfig?.filters;
     let orderBy = null;
@@ -128,15 +128,13 @@ export default class DataService {
     this.allowedFields = [];
     if (fields && Object.keys(fields).length > 0) {
       Object.keys(fields).forEach((field) => {
-        if (columns && field in columns) {
-          const f = {
-            ...fields[field],
-            columnName: field,
-            metadata: columns[field],
-          };
-          if (this.isFieldAllowed(f)) {
-            this.allowedFields.push(f);
-          }
+        const f = {
+          ...fields[field],
+          columnName: field,
+          metadata: columns?.[field] ?? {},
+        };
+        if (this.isFieldAllowed(f)) {
+          this.allowedFields.push(f);
         }
       });
     }

--- a/src/packages/shared/src/modules/widget/selectors.js
+++ b/src/packages/shared/src/modules/widget/selectors.js
@@ -63,31 +63,21 @@ export const getWidgetColumns = createSelector(
       return [];
     }
 
-    let columns;
     const relevantProps = dataset.attributes.widgetRelevantProps;
     const datasetMeta = dataset.attributes.metadata[0];
-    if (!relevantProps || relevantProps.length === 0) {
-      if (datasetMeta.attributes.columns) {
-        columns = Object.keys(datasetMeta.attributes.columns).map((prop) => ({
-          ...datasetMeta.attributes.columns[prop],
-          identifier: prop,
-          name: prop,
-          type: getColumnDataType(prop, fields),
-        }));
-      } else {
-        columns = (fields || []).map(field => ({
-          identifier: field.columnName,
-          name: field.columnName,
-          type: getColumnDataType(field.columnName, fields),
-        }));
-      }
-    } else {
-      columns = relevantProps.map((prop) => ({
-        ...datasetMeta.attributes.columns[prop],
-        identifier: prop,
-        name: prop,
-        type: getColumnDataType(prop, fields),
+
+    let columns = [];
+    if (fields) {
+      columns = fields.map(field => ({
+        ...(datasetMeta.attributes.columns?.[field.columnName] ?? {}),
+        identifier: field.columnName,
+        name: field.columnName,
+        type: getColumnDataType(field.columnName, fields),
       }));
+
+      if (relevantProps?.length > 0) {
+        columns = columns.filter(column => relevantProps.indexOf(column.name) !== -1);
+      }
     }
 
     if (configuration.chartType === "pie") {

--- a/src/packages/shared/src/modules/widget/selectors.js
+++ b/src/packages/shared/src/modules/widget/selectors.js
@@ -67,12 +67,20 @@ export const getWidgetColumns = createSelector(
     const relevantProps = dataset.attributes.widgetRelevantProps;
     const datasetMeta = dataset.attributes.metadata[0];
     if (!relevantProps || relevantProps.length === 0) {
-      columns = Object.keys(datasetMeta.attributes.columns).map((prop) => ({
-        ...datasetMeta.attributes.columns[prop],
-        identifier: prop,
-        name: prop,
-        type: getColumnDataType(prop, fields),
-      }));
+      if (datasetMeta.attributes.columns) {
+        columns = Object.keys(datasetMeta.attributes.columns).map((prop) => ({
+          ...datasetMeta.attributes.columns[prop],
+          identifier: prop,
+          name: prop,
+          type: getColumnDataType(prop, fields),
+        }));
+      } else {
+        columns = (fields || []).map(field => ({
+          identifier: field.columnName,
+          name: field.columnName,
+          type: getColumnDataType(field.columnName, fields),
+        }));
+      }
     } else {
       columns = relevantProps.map((prop) => ({
         ...datasetMeta.attributes.columns[prop],


### PR DESCRIPTION
This PR changes the logic that determines the fields available in the UI, and by doing so, fixes two crashes.

From now on the source of truth is the result of the `/fields` request.
If the dataset has an optional `widgetRelevantProps` attribute in its metadata, we use it to filter the result of `/fields`.
If it has an optional `columns` attribute we attach the fields metadata to the result of `/fields`.

This means that if we only have the results of `/fields`, we correctly display the UI (first crash). It also means that if we have the `widgetRelevantProps` attribute but not `columns`, it also works correctly (second crash).

## Testing instructions

1. Restore the widget `97de71f7-1976-4190-9d4a-216e81de1948`

Make sure it is correctly rendered, and that the “category” and “value” columns are restored and have a few options.

2. Restore the widget `0b246b3f-3a2d-4f0d-9bdc-027f0343bee9`

Make the same checks.

## Pivotal Tracker

Not tracked. Widgets reported by WRI as not working.
