### PR TITLE
Fix issue with map widgets when saving them without changing the default layer selected

### DIFF
--- a/src/applications/widget-editor/src/components/map-info/component.js
+++ b/src/applications/widget-editor/src/components/map-info/component.js
@@ -40,6 +40,12 @@ const MapInfo = ({ editor, configuration, patchConfiguration }) => {
   const options = generateOptions(layers);
   const selectedOption = options.find((o) => o.value === configuration.layer);
 
+  if (!selectedOption) {
+    patchConfiguration({
+      layer: options[0].value
+    });
+  }
+
   const handleChange = (option) => {
     patchConfiguration({
       layer: option.value,
@@ -65,7 +71,7 @@ const MapInfo = ({ editor, configuration, patchConfiguration }) => {
         <FormLabel htmlFor="options-title">Layers</FormLabel>
         <Select
           onChange={(option) => handleChange(option)}
-          value={selectedOption || options[0]}
+          value={selectedOption}
           options={options}
           styles={InputStyles}
         />

--- a/src/applications/widget-editor/src/components/map-info/component.js
+++ b/src/applications/widget-editor/src/components/map-info/component.js
@@ -40,7 +40,7 @@ const MapInfo = ({ editor, configuration, patchConfiguration }) => {
   const options = generateOptions(layers);
   const selectedOption = options.find((o) => o.value === configuration.layer);
 
-  if (!selectedOption) {
+  if (!selectedOption && options.length > 0) {
     patchConfiguration({
       layer: options[0].value
     });


### PR DESCRIPTION
This PR fixes an issue consisting of the layer IDs not being persisted in the JSON object when users don't change the layer selected by default.

## Testing instructions

Select the `Map` visualization type in the playground and click on the `Save` button without changing the layer selected. Both fields `widgetConfig.layer_id` and `widgetConfig.paramsConfig.layer` should hold the corresponding layer ID _(those two fields were null before this fix)._

## Pivotal Tracker
- https://www.pivotaltracker.com/story/show/173189486
