### PR TITLE
Render advanced widgets in the editor

### DIFF
--- a/src/applications/renderer/src/components/chart/component.js
+++ b/src/applications/renderer/src/components/chart/component.js
@@ -174,7 +174,7 @@ class Chart extends React.Component {
   }
 
   noDataAvailable() {
-    return !this.standalone && !this.props.editor.widgetData;
+    return !this.standalone && !this.props.advanced && !this.props.editor.widgetData;
   }
 
   // XXX: makes sure custom charts has nessesary info to render

--- a/src/applications/renderer/src/components/legend/component.js
+++ b/src/applications/renderer/src/components/legend/component.js
@@ -31,6 +31,8 @@ function resolveValue(val) {
 }
 
 const Legend = ({
+  widget,
+  advanced,
   configuration,
   schemeColor,
   selectedColor,
@@ -41,7 +43,8 @@ const Legend = ({
   compact,
 }) => {
   const isPie = configuration.chartType === "pie";
-  const isSingleColorSelection = !isPie && !isObjectLike(configuration.color);
+  const isSingleColorSelection = (!advanced && !isPie && !isObjectLike(configuration.color))
+    || (advanced && !widget.legend?.length);
 
   const handleChange = (option) => {
     const color = option.identifier === "___single_color" ? null : option;
@@ -66,7 +69,7 @@ const Legend = ({
           </StyledColorsBox>
         </StyledColorsBoxContainer>
       )}
-      {!isSingleColorSelection && (
+      {!isSingleColorSelection && !advanced && (
         <StyledColorsBoxContainer overflowIsHidden={true}>
           {widgetData &&
             widgetData.map((node, index) => {
@@ -81,21 +84,44 @@ const Legend = ({
             })}
         </StyledColorsBoxContainer>
       )}
-      <StyledDropdownBox>
-        <Select
-          align="horizontal"
-          relative={true}
-          menuPlacement="top"
-          value={selectedColor}
-          onChange={handleChange}
-          getOptionLabel={(option) => option.alias}
-          getOptionValue={(option) => option.identifier}
-          options={columns}
-          configuration={configuration}
-          isCustom
-          isPopup
-        />
-      </StyledDropdownBox>
+      {!isSingleColorSelection && !!advanced && (
+        <StyledColorsBoxContainer overflowIsHidden={true}>
+          {widget.legend[0].values.map((item) => (
+            <StyledColorsBox alignCenter={true} key={item.label}>
+              <StyledColorDot color={item.value} />
+              {resolveValue(item.label) || '−'}
+            </StyledColorsBox>
+          ))}
+          {widgetData &&
+            widgetData.map((node, index) => {
+              return (
+                <StyledColorsBox alignCenter={true} key={`${isPie ? node.x : node.color}-${index}`}>
+                  <StyledColorDot
+                    color={resolveSchemeColor(activeScheme.category, index)}
+                  />
+                  {resolveValue(isPie ? node.x : node.color) || '−'}
+                </StyledColorsBox>
+              );
+            })}
+        </StyledColorsBoxContainer>
+      )}
+      {!advanced && (
+        <StyledDropdownBox>
+          <Select
+            align="horizontal"
+            relative={true}
+            menuPlacement="top"
+            value={selectedColor}
+            onChange={handleChange}
+            getOptionLabel={(option) => option.alias}
+            getOptionValue={(option) => option.identifier}
+            options={columns}
+            configuration={configuration}
+            isCustom
+            isPopup
+          />
+        </StyledDropdownBox>
+      )}
     </StyledContainer>
   );
 };

--- a/src/applications/renderer/src/components/legend/index.js
+++ b/src/applications/renderer/src/components/legend/index.js
@@ -10,6 +10,7 @@ import * as themeSelectors from "@widget-editor/shared/lib/modules/theme/selecto
 
 export default redux.connectState(
   (state) => ({
+    advanced: state.editor.advanced,
     widget: state.widget,
     configuration: state.configuration,
     selectedColor: widgetSelectors.getSelectedColor(state),


### PR DESCRIPTION
This PR fixes an issue where the advanced widgets wouldn't be rendered in the editor.

The PR actually fixes two issues:
1. The chart wouldn't be rendered
2. The legend would be incorrect

The tooltip doesn't work at this point because v2 requires specific signals to be added to the marks. Since the user is free to edit the Vega config as they wish, I'm not sure we should do anything about this issue.

Please also note that the hook to get the config is not working right now. This is tracked in this [separate task](https://www.pivotaltracker.com/story/show/173442811).

## Testing instructions

Restore this widget: `c1d7cb83-5f50-43eb-8ea0-6f7ecd4e1b69`.

Make sure a pie chart is displayed and that the legend makes sense.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173132511).
