### PR TITLE
Change the format of the Y axis value in the tooltip

### DIFF
--- a/src/packages/core/src/charts/bars-horizontal.ts
+++ b/src/packages/core/src/charts/bars-horizontal.ts
@@ -183,7 +183,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
               column: "y",
               property: this.resolveName('y'),
               type: "number",
-              format: this.resolveFormat('y'),
+              format: '.2s',
             },
             {
               column: "x",

--- a/src/packages/core/src/charts/bars-stacked.ts
+++ b/src/packages/core/src/charts/bars-stacked.ts
@@ -139,7 +139,7 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
               column: "y",
               property: this.resolveName('y'),
               type: "number",
-              format: this.resolveFormat('y'),
+              format: '.2s',
             },
             {
               column: "x",

--- a/src/packages/core/src/charts/bars.ts
+++ b/src/packages/core/src/charts/bars.ts
@@ -139,7 +139,7 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
               column: "y",
               property: this.resolveName('y'),
               type: "number",
-              format: this.resolveFormat('y'),
+              format: '.2s',
             },
             {
               column: "x",

--- a/src/packages/core/src/charts/line.ts
+++ b/src/packages/core/src/charts/line.ts
@@ -115,7 +115,7 @@ export default class Line extends ChartsCommon implements Charts.Line {
               column: "y",
               property: this.resolveName('y'),
               type: "number",
-              format: this.resolveFormat('y'),
+              format: '.2s',
             },
             {
               column: "x",

--- a/src/packages/core/src/charts/pie.ts
+++ b/src/packages/core/src/charts/pie.ts
@@ -178,7 +178,6 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
 
   getChart() {
     const parseSignals = new ParseSignals(this.schema, this.widgetConfig, this.isDate()).serializeSignals();
-    console.log(parseSignals);
     return parseSignals;
   }
 }

--- a/src/packages/core/src/charts/pie.ts
+++ b/src/packages/core/src/charts/pie.ts
@@ -79,7 +79,7 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
               column: "value",
               property: this.resolveName('y'),
               type: "number",
-              format: this.resolveFormat('y'),
+              format: '.2s',
             },
             {
               column: "category",
@@ -178,6 +178,7 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
 
   getChart() {
     const parseSignals = new ParseSignals(this.schema, this.widgetConfig, this.isDate()).serializeSignals();
+    console.log(parseSignals);
     return parseSignals;
   }
 }

--- a/src/packages/core/src/charts/scatter.ts
+++ b/src/packages/core/src/charts/scatter.ts
@@ -68,7 +68,7 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
               column: "y",
               property: this.resolveName('y'),
               type: "number",
-              format: this.resolveFormat('y'),
+              format: '.2s',
             },
             {
               column: "x",


### PR DESCRIPTION
In v1, the Y axis value was always formatted with `s`, and in the tooltip, the value was always formatted with `.2s`.

In v2, the user has the possibility to change the default format, `s`, to any value and this applies both to the axis and the value in the tooltip. We've got some reports from WRI that they don't like the format of the value in the tooltip.

My initial thought was to use `.2s` as a default format everywhere, but this forces most axes to have two decimal numbers, even when that doesn't make sense. Instead, I've made changes so the customisable format is only applied to the axes, and so that the tooltip always uses `.2s`.

## Testing instructions

1. Restore this widget: `0948ea75-1eb2-42d2-89c2-f4dcff93b51c` (dataset: `acf42a1b-104b-4f81-acd0-549f805873fb`)

Make sure it matches what's in v1: https://resourcewatch.org/data/explore/foo053-Food-Price-Spikes.

2. Update the chart type to bar

Make sure the axis still looks good (no unnecessary decimals).

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173442137).