### PR TITLE
Fix thumbnail rendering issues

### DIFF
--- a/src/applications/renderer/src/components/chart/component.js
+++ b/src/applications/renderer/src/components/chart/component.js
@@ -158,7 +158,8 @@ class Chart extends React.Component {
           
         if (
           configuration.interaction_config &&
-          configuration.interaction_config.length
+          configuration.interaction_config.length &&
+          !this.props.thumbnail
         ) {
           this.instantiateTooltip(configuration);
         } 

--- a/src/applications/renderer/src/components/standalone/component.js
+++ b/src/applications/renderer/src/components/standalone/component.js
@@ -42,7 +42,8 @@ const Standalone = ({ thumbnail, widgetConfig }) => {
     <Fragment>
       {!isMap && (
         <Suspense>
-          {widgetConfig.hasOwnProperty('legend') && widgetConfig.legend.length > 0 && <Legend widgetConfig={widgetConfig}/>}
+          {widgetConfig.hasOwnProperty('legend') && widgetConfig.legend.length > 0 && !thumbnail
+            && <Legend widgetConfig={widgetConfig}/>}
           <Chart
             thumbnail={thumbnail}
             standalone


### PR DESCRIPTION
This PR disables the tooltip and the legend of the widgets when rendered as thumbnails.

## Testing instructions

1. Edit [this line](https://github.com/Vizzuality/widget-editor/blob/75dd261fb7fcdb94cecc02f88e9c2bc5966d1d2e/src/playground/widget-editor/src/components/playground-renderer/component.js#L17) to set `thumbnail` to `true`.
2. Restore this widget: `8c37f930-335f-401f-bdbc-9a68da71a89d` (dataset: `fb7e2b65-98cb-4d30-89d8-8e620f0beb71`)
3. Open the playground and click the “View renderer” button

The pie chart must not have a legend and if you hover the slices, you should not see a tooltip.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173442180).
