### PR TITLE
RW-adapter fix: use application parameter in URL

### DIFF
--- a/src/adapters/rw-adapter/src/index.ts
+++ b/src/adapters/rw-adapter/src/index.ts
@@ -90,7 +90,7 @@ export default class RwAdapter implements Adapter.Service {
       ${this.endpoint}
       /dataset/
       ${this.datasetId}?
-      ${applications.join(",")}
+      application=${applications.join(",")}
       &env=${env}
       &language=${locale}
       &includes=${includes}
@@ -104,7 +104,6 @@ export default class RwAdapter implements Adapter.Service {
     // -- Serialize widgets
     // -- We dont want to expose widgets where { published: true }
     // -- These are user created widgets
-
     const serializeDataset = {
       ...dataset,
       attributes: {

--- a/src/playground/widget-editor/src/components/editor-options/component.js
+++ b/src/playground/widget-editor/src/components/editor-options/component.js
@@ -74,6 +74,9 @@ class EditorOptions extends React.Component {
           <option value="a86d906d-9862-4783-9e30-cdb68cd808b8">
             Global Power Plant Database
           </option>
+          <option value="d9034fa9-8db0-4d52-b018-46fae37d3136">
+            Terrestrial Ecoregions
+          </option>
           <option value="1bc94710-d7ec-46f9-aa27-edddd87b1625">
             Cold Water Corals
           </option>


### PR DESCRIPTION
Minor fix for the URL used when fetching datasets in the RW adapter.
