### PR TITLE
Prevent crash from accessing non-existing metadata

### DIFF
--- a/src/packages/shared/src/modules/widget/selectors.js
+++ b/src/packages/shared/src/modules/widget/selectors.js
@@ -64,12 +64,12 @@ export const getWidgetColumns = createSelector(
     }
 
     const relevantProps = dataset.attributes.widgetRelevantProps;
-    const datasetMeta = dataset.attributes.metadata[0];
+    const datasetMeta = dataset.attributes.metadata?.[0];
 
     let columns = [];
     if (fields) {
       columns = fields.map(field => ({
-        ...(datasetMeta.attributes.columns?.[field.columnName] ?? {}),
+        ...(datasetMeta?.attributes.columns?.[field.columnName] ?? {}),
         identifier: field.columnName,
         name: field.columnName,
         type: getColumnDataType(field.columnName, fields),


### PR DESCRIPTION
This PR fixes an issue where, if the dataset wouldn't have any metadata, it would crash.

## Testing instructions

1. Open this dataset with the editor: `852f2275-91a8-4500-9f10-89880dc53f22` (don't set any widget)
2. Open the sandbox

The editor must not crash.

## Pivotal Tracker

Not tracked. The bug was uncovered by a fix Pablo did in #63.
