### PR TITLE
add missing title to maps

### DIFF
--- a/src/applications/renderer/src/components/renderer/component.js
+++ b/src/applications/renderer/src/components/renderer/component.js
@@ -26,7 +26,8 @@ const Renderer = ({
   configuration,
   compact,
   changeBbox,
-  interactionEnabled
+  interactionEnabled,
+  widgetName
 }) => {
   const { restoring, initialized } = editor;
   const missingWidget =
@@ -56,6 +57,7 @@ const Renderer = ({
         <Standalone
           thumbnail={thumbnail}
           widgetConfig={widgetConfig}
+          widgetName={widgetName}
           theme={theme}
           changeBbox={changeBbox}
           interactionEnabled={interactionEnabled}
@@ -97,7 +99,7 @@ const Renderer = ({
           {editor.widget && editor.layers && (
             <Map
               mapConfiguration={configuration.map}
-              caption={configuration.caption}
+              caption={editor.widget?.attributes?.name}
               layerId={configuration.layer}
               interactionEnabled={!standalone}
               widget={editor.widget}

--- a/src/applications/renderer/src/components/standalone/component.js
+++ b/src/applications/renderer/src/components/standalone/component.js
@@ -8,7 +8,13 @@ import Legend from './legend';
 const Chart = React.lazy(() => import("../chart"));
 const Map = React.lazy(() => import("@widget-editor/map"));
 
-const Standalone = ({ thumbnail, widgetConfig, changeBbox, interactionEnabled }) => {
+const Standalone = ({ 
+  thumbnail,
+  widgetConfig,
+  changeBbox,
+  interactionEnabled,
+  widgetName
+}) => {
   const isMap = widgetConfig?.paramsConfig?.visualizationType === "map";
   const [{ layerData, isLoadingLayers, isErrorLayers }] = useLayerData(
     widgetConfig?.paramsConfig?.layer,
@@ -68,7 +74,7 @@ const Standalone = ({ thumbnail, widgetConfig, changeBbox, interactionEnabled })
               zoom: widgetConfig.zoom || 2,
               basemap: widgetConfig.basemap || null,
             }}
-            caption={widgetConfig?.paramsConfig?.caption || null}
+            caption={widgetName}
             layers={[layerData]}
             changeBbox={changeBbox}
             interactionEnabled={interactionEnabled}

--- a/src/playground/widget-editor/src/components/editor-options/component.js
+++ b/src/playground/widget-editor/src/components/editor-options/component.js
@@ -74,8 +74,8 @@ class EditorOptions extends React.Component {
           <option value="a86d906d-9862-4783-9e30-cdb68cd808b8">
             Global Power Plant Database
           </option>
-          <option value="d9034fa9-8db0-4d52-b018-46fae37d3136">
-            Terrestrial Ecoregions
+          <option value="5b5a21ac-0835-43fb-86b9-64b93d472e10">
+            Endangered Species Critical Habitats
           </option>
           <option value="1bc94710-d7ec-46f9-aa27-edddd87b1625">
             Cold Water Corals

--- a/src/playground/widget-editor/src/components/playground-renderer/component.js
+++ b/src/playground/widget-editor/src/components/playground-renderer/component.js
@@ -16,6 +16,7 @@ const PlaygroundRenderer = ({ activeWidget }) => {
           <Renderer
             thumbnail={false}
             // widgetConfig={widgetTest.data.attributes.widgetConfig}
+            // widgetName={widgetTest.data.attributes.name}
             widgetConfig={activeWidget.attributes.widgetConfig}
           />
         </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/86765639-b4ff5780-c049-11ea-881c-7a10cd321c22.png)

This PR adds the missing map title to map widgets.

## Testing instructions

Test a dataset that has a `defaultEditableWidget` of type `map`. For example: "2019 Endangered Species Critical Habitats"

## Pivotal Tracker

https://www.pivotaltracker.com/n/projects/2154258/stories/173680505
