### PR TITLE
Bug/pie slices order

### DIFF
--- a/src/adapters/rw-adapter/src/index.ts
+++ b/src/adapters/rw-adapter/src/index.ts
@@ -90,7 +90,7 @@ export default class RwAdapter implements Adapter.Service {
       ${this.endpoint}
       /dataset/
       ${this.datasetId}?
-      ${applications.join(",")}
+      application=${applications.join(",")}
       &env=${env}
       &language=${locale}
       &includes=${includes}
@@ -104,7 +104,6 @@ export default class RwAdapter implements Adapter.Service {
     // -- Serialize widgets
     // -- We dont want to expose widgets where { published: true }
     // -- These are user created widgets
-
     const serializeDataset = {
       ...dataset,
       attributes: {

--- a/src/applications/renderer/src/components/renderer/component.js
+++ b/src/applications/renderer/src/components/renderer/component.js
@@ -8,7 +8,7 @@ import {
 
 import ChartTitle from '../chart-title';
 
-// Lazy components 
+// Lazy components
 const Chart = React.lazy(() => import("../chart"));
 const SelectChart = React.lazy(() => import("../select-chart"));
 const Legend = React.lazy(() => import("../legend"));
@@ -32,8 +32,8 @@ const Renderer = ({
   const missingWidget =
     initialized && !restoring && widget && Object.keys(widget).length === 0;
 
-  const isMap = configuration.visualizationType === "map";  
-  
+  const isMap = configuration.visualizationType === "map";
+
   if (restoring) {
     return (
       <StyledContainer>

--- a/src/applications/widget-editor/src/components/donut-radius/component.js
+++ b/src/applications/widget-editor/src/components/donut-radius/component.js
@@ -1,5 +1,6 @@
 // TODO: Rename this filter!
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
+import debounce from 'lodash/debounce';
 
 import useDebounce from "hooks/use-debounce";
 
@@ -19,15 +20,16 @@ const DonutRadius = ({
   onChange = (data) => {},
 }) => {
   const [localValue, setLocalValue] = useState({ value, key: null });
-  const debouncedValue = useDebounce(localValue, 400);
 
-  useEffect(() => {
-    if (!debouncedValue.key) {
-      onChange(debouncedValue.value);
-    } else {
-      onChange(debouncedValue.value, debouncedValue.key);
-    }
-  }, [debouncedValue]);
+  const changeValue = (data) => {
+    setLocalValue(data);
+    debounceOnChange(data);
+  }
+
+  const debounceOnChange = debounce(q => {
+    onChange(q.value, q.key);
+  }, 1000);
+
 
   return (
     <InputGroup>
@@ -39,7 +41,7 @@ const DonutRadius = ({
             type="number"
             name="options-donut-radius"
             onChange={(e) =>
-              setLocalValue({ value: e.target.value, key: "donut-radius" })
+              changeValue({ value: e.target.value, key: "donut-radius" })
             }
           />
         </FlexController>
@@ -48,7 +50,7 @@ const DonutRadius = ({
             min={min}
             max={max}
             value={localValue.value}
-            onChange={(v) => setLocalValue({ value: v, key: null })}
+            onChange={(v) => changeValue({ value: v, key: null })}
           />
         </FlexController>
       </FlexContainer>

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -19,7 +19,7 @@ const TableView = React.lazy(() => import("../table-view"));
 const Typography = React.lazy(() => import("../typography"));
 const ColorShemes = React.lazy(() => import("../color-shemes"));
 const DonutRadius = React.lazy(() => import("../donut-radius"));
-const SlizeCount = React.lazy(() => import("../slize-count"));
+const SliceCount = React.lazy(() => import("../slice-count"));
 const MapInfo = React.lazy(() => import("../map-info"));
 
 const StyleEditorOptionsInfo = styled.div`
@@ -102,7 +102,7 @@ const EditorOptions = ({
     if (type === "donut-radius") {
       patchConfiguration({ donutRadius: parseInt(value) });
     }
-    if (type === "slize-count") {
+    if (type === "slice-count") {
       patchConfiguration({ sliceCount: parseInt(value) });
     }
   };
@@ -172,10 +172,10 @@ const EditorOptions = ({
                 </Suspense>
                 <Suspense fallback={<div>Loading...</div>}>
                   {sliceCount && data && (
-                    <SlizeCount
+                    <SliceCount
                       value={sliceCount}
                       data={data}
-                      onChange={(value) => handleChange(value, "slize-count")}
+                      onChange={(value) => handleChange(value, "slice-count")}
                     />
                   )}
                 </Suspense>

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -89,23 +89,26 @@ const EditorOptions = ({
   dataService,
   isMap,
 }) => {
-  const handleChange = (value, type) => {
-    if (type === "limit") {
-      patchConfiguration({ limit: value });
-    }
-    if (type === "orderBy") {
-      patchConfiguration({ orderBy: value });
-    }
-    if (type === "groupBy") {
-      patchConfiguration({ groupBy: value });
-    }
-    if (type === "donut-radius") {
-      patchConfiguration({ donutRadius: parseInt(value) });
-    }
-    if (type === "slice-count") {
-      patchConfiguration({ sliceCount: parseInt(value) });
-    }
+
+  const handleSliceCount = (value) => {
+    patchConfiguration({ sliceCount: parseInt(value) });
   };
+
+  const handleDonutRadius = (value) => {
+    patchConfiguration({ donutRadius: parseInt(value) });
+  }
+
+  const handleOrderBy = (value) => {
+    patchConfiguration({ orderBy: value });
+  }
+
+  const handleGroupBy = (value) => {
+    patchConfiguration({ groupBy: value });
+  }
+
+  const handleLimit = (value) => {
+    patchConfiguration({ limit: value });
+  }
 
   if (!initialized || restoring) {
     return (
@@ -144,16 +147,16 @@ const EditorOptions = ({
             {!isMap && !advanced && (
               <AccordionSection title="Order">
                 <OrderValues
-                  onChange={(value) => handleChange(value, "orderBy")}
+                  onChange={(value) => handleOrderBy(value)}
                 />
                 <GroupValues
-                  onChange={(value) => handleChange(value, "groupBy")}
+                  onChange={(value) => handleGroupBy(value)}
                 />
                 {limit && (
                   <QueryLimit
                     min={0}
                     max={500}
-                    onChange={(value) => handleChange(value, "limit")}
+                    onChange={(value) => handleLimit(value)}
                     label="Limit"
                     value={limit}
                   />
@@ -166,7 +169,7 @@ const EditorOptions = ({
                   {donutRadius && (
                     <DonutRadius
                       value={donutRadius}
-                      onChange={(value) => handleChange(value, "donut-radius")}
+                      onChange={(value) => handleDonutRadius(value)}
                     />
                   )}
                 </Suspense>
@@ -175,7 +178,7 @@ const EditorOptions = ({
                     <SliceCount
                       value={sliceCount}
                       data={data}
-                      onChange={(value) => handleChange(value, "slice-count")}
+                      onChange={(value) => handleSliceCount(value)}
                     />
                   )}
                 </Suspense>

--- a/src/applications/widget-editor/src/components/order-values/component.js
+++ b/src/applications/widget-editor/src/components/order-values/component.js
@@ -64,7 +64,7 @@ const OrderValues = ({ orderBy, columns, setFilters, onChange }) => {
   return (
     <FlexContainer>
       <InputGroup>
-        <FormLabel htmlFor="options-title">Order by</FormLabel>
+        <FormLabel htmlFor="options-order-title">Order by</FormLabel>
         <FlexContainer row={true}>
           <FlexController contain={90}>
             <Select

--- a/src/applications/widget-editor/src/components/query-limit/component.js
+++ b/src/applications/widget-editor/src/components/query-limit/component.js
@@ -31,7 +31,7 @@ const QueryLimit = ({
   onChange = (data) => {},
 }) => {
   const [localValue, setLocalValue] = useState({ value, key: null });
-  const debouncedValue = useDebounce(localValue, 400);
+  const debouncedValue = useDebounce(localValue, 1000);
 
   useEffect(() => {
     if (!debouncedValue.key) {

--- a/src/applications/widget-editor/src/components/slice-count/component.js
+++ b/src/applications/widget-editor/src/components/slice-count/component.js
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from "react";
-
-import useDebounce from "hooks/use-debounce";
+import React, { useState } from "react";
+import debounce from 'lodash/debounce';
 
 import FlexContainer from "styles-common/flex";
 import FlexController from "styles-common/flex-controller";
@@ -9,42 +8,29 @@ import FormLabel from "styles-common/form-label";
 import InputGroup from "styles-common/input-group";
 import Input from "styles-common/input";
 
-// TODO: Move me
-const getGroupedCount = (data) => {
-  const out = {};
-
-  data.forEach((entry) => {
-    if (out.hasOwnProperty(entry.x)) {
-      out[entry.x] = out[entry.x] + 1;
-    } else {
-      out[entry.x] = 1;
-    }
-  });
-
-  return Object.values(out).length;
-};
-
 const SliceCount = ({
   min = 1,
-  value = 40,
+  value = null,
   data = null,
   minDistance = 1,
   onChange = (data) => {},
 }) => {
-  const [localValue, setLocalValue] = useState({ value, key: null });
-  const debouncedValue = useDebounce(localValue, 400);
+  const [localValue, setLocalValue] = useState({ value: value, key: null });
 
-  useEffect(() => {
-    if (!debouncedValue.key) {
-      onChange(debouncedValue.value);
-    } else {
-      onChange(debouncedValue.value, debouncedValue.key);
+  const changeValue = (data) => {
+    if (data.value !== 0) {
+      setLocalValue(data);
+      debounceOnChange(data);
     }
-  }, [debouncedValue, onChange]);
+  }
+
+  const debounceOnChange = debounce(q => {
+    onChange(q.value, q.key);
+  }, 1000);
 
   return (
     <InputGroup>
-      <FormLabel htmlFor="options-donut-radius">
+      <FormLabel htmlFor="options-slice-count">
         Slice count (donut and pie charts)
       </FormLabel>
       <FlexContainer row={true}>
@@ -52,18 +38,18 @@ const SliceCount = ({
           <Input
             value={localValue.value}
             type="number"
-            name="options-donut-radius"
+            name="options-slice-count"
             onChange={(e) =>
-              setLocalValue({ value: e.target.value, key: "slice-count" })
+              changeValue({ value: e.target.value, key: "slice-count" })
             }
           />
         </FlexController>
         <FlexController contain={80}>
           <Slider
             min={min}
-            max={data ? getGroupedCount(data) : 10}
+            max={10} // TODO: Can we be dynamic with this?
             value={localValue.value}
-            onChange={(v) => setLocalValue({ value: v, key: null })}
+            onChange={(v) => changeValue({ value: v, key: null })}
           />
         </FlexController>
       </FlexContainer>

--- a/src/applications/widget-editor/src/components/slice-count/component.js
+++ b/src/applications/widget-editor/src/components/slice-count/component.js
@@ -24,7 +24,7 @@ const getGroupedCount = (data) => {
   return Object.values(out).length;
 };
 
-const SlizeCount = ({
+const SliceCount = ({
   min = 1,
   value = 40,
   data = null,
@@ -40,12 +40,12 @@ const SlizeCount = ({
     } else {
       onChange(debouncedValue.value, debouncedValue.key);
     }
-  }, [debouncedValue]);
+  }, [debouncedValue, onChange]);
 
   return (
     <InputGroup>
       <FormLabel htmlFor="options-donut-radius">
-        Slize count (donut and pie charts)
+        Slice count (donut and pie charts)
       </FormLabel>
       <FlexContainer row={true}>
         <FlexController contain={20}>
@@ -54,7 +54,7 @@ const SlizeCount = ({
             type="number"
             name="options-donut-radius"
             onChange={(e) =>
-              setLocalValue({ value: e.target.value, key: "slize-count" })
+              setLocalValue({ value: e.target.value, key: "slice-count" })
             }
           />
         </FlexController>
@@ -71,4 +71,4 @@ const SlizeCount = ({
   );
 };
 
-export default SlizeCount;
+export default SliceCount;

--- a/src/applications/widget-editor/src/components/slice-count/index.js
+++ b/src/applications/widget-editor/src/components/slice-count/index.js
@@ -1,0 +1,3 @@
+import DonutSlicesComponent from "./component";
+
+export default DonutSlicesComponent;

--- a/src/applications/widget-editor/src/components/slize-count/index.js
+++ b/src/applications/widget-editor/src/components/slize-count/index.js
@@ -1,3 +1,0 @@
-import DonutSlizesComponent from "./component";
-
-export default DonutSlizesComponent;

--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -130,9 +130,6 @@ function* checkWithProxyIfShouldUpdate(payload) {
 }
 
 function* updateWidget() {
-  if (yield cancelled()) {
-    console.log('Im canceled!');
-  }
   const {
     widgetEditor: { editor, configuration, theme },
   } = yield select();

--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -1,4 +1,4 @@
-import { takeLatest, put, call, select, cancel } from "redux-saga/effects";
+import { takeLatest, put, call, select, cancel, cancelled, takeEvery } from "redux-saga/effects";
 import isEqual from 'lodash/isEqual';
 import { getAction } from "@widget-editor/shared/lib/helpers/redux";
 
@@ -111,7 +111,6 @@ function* initializeWidget({ payload }) {
 // If no updates required we yield cancel
 function* checkWithProxyIfShouldUpdate(payload) {
   const { widgetEditor } = yield select();
-
   // We only want to resolve proxy if the editor itself is initialized
   if (!widgetEditor.editor.initialized) {
     yield cancel();
@@ -131,6 +130,9 @@ function* checkWithProxyIfShouldUpdate(payload) {
 }
 
 function* updateWidget() {
+  if (yield cancelled()) {
+    console.log('Im canceled!');
+  }
   const {
     widgetEditor: { editor, configuration, theme },
   } = yield select();
@@ -185,6 +187,7 @@ function* updateWidgetData() {
   if (!widgetEditor.editor.initialized) {
     yield cancel();
   }
+
   if (widgetEditor.configuration.visualizationType !== "map") {
     let widgetData;
 
@@ -239,7 +242,8 @@ export default function* baseSaga() {
     [
       getAction("CONFIGURATION/patchConfiguration"),
       getAction("EDITOR/THEME/setTheme"),
-      getAction('WIDGET/setWidget')
+      getAction('WIDGET/setWidget'),
+      getAction("EDITOR/setEditor")
     ],
     checkWithProxyIfShouldUpdate
   );

--- a/src/packages/core/src/charts/pie.ts
+++ b/src/packages/core/src/charts/pie.ts
@@ -20,6 +20,7 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
     scheme: any
   ) {
     super(configuration, editor, widgetData, scheme);
+
     this.configuration = configuration;
     this.editor = editor;
     this.schema = schema;
@@ -176,7 +177,6 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
 
   setLegend() {
     const scheme = this.resolveScheme();
-
     if (!this.widgetData) {
       return null;
     }

--- a/src/packages/core/src/charts/pie.ts
+++ b/src/packages/core/src/charts/pie.ts
@@ -1,3 +1,4 @@
+import uniqBy from 'lodash/uniqBy';
 import { Charts, Vega, Generic, Widget } from "@widget-editor/types";
 
 import ChartsCommon from './chart-common';
@@ -98,7 +99,7 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
           data: "table",
           field: 'value',
         },
-        range: 'category20',
+        range: this.scheme.category,
       },
     ];
   }
@@ -153,7 +154,7 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
           {
             "type": "formula",
             "as": "category",
-            "expr": "datum.rank < 6 ? datum.x : 'Others'"
+            "expr": `datum.rank < ${this.configuration.sliceCount} ? datum.x : 'Others'`
           },
           {
             "type": "aggregate",
@@ -180,16 +181,23 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
       return null;
     }
 
+    const values = uniqBy(
+      this.widgetData.map((d, i) => ({ ...d, x: i + 1 < this.configuration.sliceCount ? d.x : 'Others' })),
+      'x'
+    )
+      .slice(0, this.configuration.sliceCount)
+      .map((d, i) => ({
+        label: d.x,
+        value: scheme.range.category20[i % this.configuration.sliceCount],
+        type: 'string'
+      }));
+
     return [
       {
         type: 'color',
         label: null,
         shape: 'square',
-        values: this.widgetData.map((d: { x: string, y: number }, index) => ({
-          label: d.x,
-          value: scheme.range.category20[index % scheme.range.category20.length],
-          type: 'string',
-        }))
+        values,
       }
     ];
   }

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -281,12 +281,13 @@ export default class FiltersService implements Filters.Service {
     }
 
     // If the user sorts by a field that is aggregated, then, instead of ordering by the name of the
-    // field, we order by its alias
-    // Since only the value column (which has the alias “y”) can be aggregated, the sort field is
-    // “y”
-    // The reason for doing this is that the API doesn't support functions in the ORDER BY
-    // (ex: ORDER BY count(number))
-    if (aggregateFunction && orderByField === this.configuration?.value?.name) {
+    // field, we order by its alias. The reason for doing this is that the API doesn't support
+    // functions in the ORDER BY (ex: ORDER BY count(number)).
+    // Nevertheless, if the user uses the same field for the category, value and order by fields,
+    // then we understand the user wants to order, not by the aggregation, but by the raw value
+    // instead (the category field). In that case, we don't replace the previous orderByField.
+    if (aggregateFunction && orderByField === this.configuration?.value?.name
+      && this.configuration?.category?.name !== orderByField) {
       orderByField = 'y';
     }
 

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -377,7 +377,3 @@ export default class FiltersService implements Filters.Service {
     return patch;
   }
 }
-
-
-// SELECT acq_date as x , count(frp) as y FROM vnp14imgtdl_nrt_global_7d WHERE frp >= 100 AND frp <= 857 GROUP BY x ORDER BY y desc LIMIT 7
-// SELECT acq_date as x, COUNT(frp) as y FROM vnp14imgtdl_nrt_global_7d WHERE frp >= 100 AND frp <= 857 GROUP BY  x ORDER BY acq_date desc LIMIT 7

--- a/src/packages/core/src/services/state-proxy.ts
+++ b/src/packages/core/src/services/state-proxy.ts
@@ -5,7 +5,7 @@ import isEqual from "lodash/isEqual";
 
 export default class StateProxy {
   chartCache: any;
-  configuration: object;
+  configuration: any;
   donutRadius?: number;
   sliceCount?: number;
   visualizationType: string;
@@ -54,6 +54,11 @@ export default class StateProxy {
       return true;
     }
 
+
+    if (this.configuration && !isEqual(this.configuration.orderBy, editor.configuration.orderBy)) {
+      return true;
+    }
+
     this.chartCache = { visualizationType, chartType, format, donutRadius, sliceCount };
     return hasUpdate && editor.initialized;
   }
@@ -78,11 +83,24 @@ export default class StateProxy {
     return updates;
   }
 
-  
+
   configurationHasUpdate(state) {
     const { configuration } = state;
+
+    // XXX: This is simlified in another pr and less greedy
     const hasUpdates = !isEqual(this.configuration, configuration) && this.configuration !== null;
+
+    // Did limit update?
+    if (this.configuration && this.configuration.limit !== configuration.limit) {
+      return true;
+    }
+
+    if (this.configuration && !isEqual(this.configuration.orderBy, configuration.orderBy)) {
+      return true;
+    }
+
     this.configuration = configuration;
+
     return hasUpdates;
   }
 
@@ -112,6 +130,7 @@ export default class StateProxy {
       this.chartHasUpdate(editorState)) {
       UPDATES.push(sagaEvents.DATA_FLOW_UPDATE_WIDGET);
     }
+
     return UPDATES;
   }
 }

--- a/src/packages/core/src/services/vega.ts
+++ b/src/packages/core/src/services/vega.ts
@@ -74,8 +74,6 @@ export default class VegaService implements Charts.Service {
     this.configuration = configuration;
     this.editor = editor;
 
-    this.sliceCount = configuration?.sliceCount || 5;
-
     this.setConfig();
     this.resolveChart();
   }
@@ -85,6 +83,7 @@ export default class VegaService implements Charts.Service {
     let chart;
 
     const data = this.widgetData;
+
     if (SUPPORTED_CHARTS.indexOf(chartType) === -1) {
       throw new Error(
         `Chart of type: ${chartType} is not supported. we support: (${SUPPORTED_CHARTS.join(

--- a/src/packages/core/src/services/vega.ts
+++ b/src/packages/core/src/services/vega.ts
@@ -80,95 +80,11 @@ export default class VegaService implements Charts.Service {
     this.resolveChart();
   }
 
-  groupSimilar(data) {
-    const combineSimilar = {};
-
-    data.forEach((node) => {
-      if (node.x in combineSimilar) {
-        combineSimilar[node.x] = {
-          ...combineSimilar[node.x],
-          y: combineSimilar[node.x].y + node.y,
-        };
-      } else {
-        combineSimilar[node.x] = { ...node };
-      }
-    });
-
-    const out = [];
-
-    Object.keys(combineSimilar).forEach((node) => {
-      out.push(combineSimilar[node]);
-    });
-
-    return out;
-  }
-
-  groupByTop(data) {
-    function sortHighToLow(a, b) {
-      if (a.y > b.y) return -1;
-      if (b.y > a.y) return 1;
-      return 0;
-    }
-
-    const combine = this.groupSimilar(data);
-
-    const sortValues = combine.sort(sortHighToLow);
-    const top5 = sortValues.slice(0, this.sliceCount);
-    const others = sortValues.slice(this.sliceCount, sortValues.length + 1);
-
-    const out = [];
-    let othersNode = { x: "Others", y: 0 };
-
-    others.forEach((node) => {
-      othersNode = { ...othersNode, y: othersNode.y + node.y };
-    });
-
-    top5.forEach((node) => {
-      out.push({ x: node.x, y: node.y });
-    });
-
-    return [...out, othersNode];
-  }
-
-  groupByColor(data) {
-    const groupColors = {};
-
-    data.forEach((node) => {
-      if (node.color) {
-        if (node.color in groupColors) {
-          groupColors[node.color] = {
-            ...groupColors[node.color],
-            y: groupColors[node.color].y + node.y,
-          };
-        } else {
-          groupColors[node.color] = node;
-        }
-      }
-    });
-
-    const out = [];
-
-    Object.keys(groupColors).forEach((node) => {
-      out.push(groupColors[node]);
-    });
-
-    return out;
-  }
-
-  resolveDataFormat() {
-    const { chartType, direction } = this.configuration;
-    if ((chartType === "pie" || chartType === "donut") && this.widgetData) {
-      return this.groupByTop(this.widgetData);
-    }
-
-    return this.widgetData;
-  }
-
   resolveChart() {
     const { chartType, direction } = this.configuration;
     let chart;
 
-    const data = this.resolveDataFormat();
+    const data = this.widgetData;
     if (SUPPORTED_CHARTS.indexOf(chartType) === -1) {
       throw new Error(
         `Chart of type: ${chartType} is not supported. we support: (${SUPPORTED_CHARTS.join(

--- a/src/packages/shared/src/modules/configuration/initial-state.js
+++ b/src/packages/shared/src/modules/configuration/initial-state.js
@@ -5,7 +5,7 @@ export default {
   visualizationType: "chart",
   rasterOnly: false,
   chartType: "bar",
-  sliceCount: 5,
+  sliceCount: 6,
   donutRadius: 100,
   map: {
     zoom: 2,

--- a/src/playground/widget-editor/src/components/editor-options/component.js
+++ b/src/playground/widget-editor/src/components/editor-options/component.js
@@ -74,6 +74,9 @@ class EditorOptions extends React.Component {
           <option value="a86d906d-9862-4783-9e30-cdb68cd808b8">
             Global Power Plant Database
           </option>
+          <option value="d9034fa9-8db0-4d52-b018-46fae37d3136">
+            Terrestrial Ecoregions
+          </option>
           <option value="1bc94710-d7ec-46f9-aa27-edddd87b1625">
             Cold Water Corals
           </option>


### PR DESCRIPTION
This PR fixes two issues of the pie/donut charts:
1. The slice count setting in the UI wouldn't be applied to the widget
2. The order by setting of the data in the UI wouldn't be applied to the widget

While working on this fix, I realised the “Order by” and “Limit” settings of the UI don't update the chart (they don't even trigger a data refetch). I've created a [new ticket for this](https://www.pivotaltracker.com/story/show/173682941) and assigned it to you @tomasmoose.

## Testing instructions

1. Restore this widget: `60ee0ec8-345e-4783-a6cf-448efd457a7d` (dataset: `ac6dcdb3-2beb-4c66-9f83-565c16c2c914`)

Make sure the slices are ordered by “Food Insecurity Status” increasing clockwise.

2. Reduce the number of slices in the UI

Make sure the widget and legend update correctly.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173680487)
