### PR TITLE
fix infinite loop for map layers

### DIFF
--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -137,7 +137,11 @@ function* updateWidget() {
     const fullState = yield select();
     const widgetData = yield call(getWidgetDataWithAdapter, fullState.widgetEditor);
 
-    if (widgetData) {
+    // XXX: Important!! only set widget data if we have it
+    // Some widgets especialy maps will return an empty array or simply nothing
+    // This will cause the editor to try and re render until we have resolved the data
+    // As our sagas will try to refetch data we will simply not call this and let the sagas cancel
+    if (widgetData && Array.isArray(widgetData) && widgetData.length > 0) {
       yield put(setEditor({ widgetData: widgetData.data }));
     }
   }
@@ -192,7 +196,11 @@ function* updateWidgetData() {
       widgetData = yield call(getWidgetDataWithAdapter, widgetEditor);
     }
 
-    if (widgetData) {
+    // XXX: Important!! only set widget data if we have it
+    // Some widgets especialy maps will return an empty array or simply nothing
+    // This will cause the editor to try and re render until we have resolved the data
+    // As our sagas will try to refetch data we will simply not call this and let the sagas cancel themself
+    if (widgetData && Array.isArray(widgetData) && widgetData.length > 0) {
       yield put(setEditor({ widgetData: widgetData.data }));
     }
 


### PR DESCRIPTION
This fixes a bug where we run into a infinite loop when no data


## Why is this happening? 

For some widgets when initialising we get empty data back, or simply an empty array. Problem is when initialising the widget we are expecting data. In this case we end up in a infinite loop where the editor sagas try to refetch data forever. 

This will happen especially for map widgets that does not care about data. what we need to do inside the widget saga is to make sure we have data before applying it. If we dont apply any data the sagas will cancel themself out. 

This will also fix the problem of layerId not set as we never got to that point. 

### Testing

Initialise the editor with this dataset: 

 `dataset: "b82eab85-0fee-4212-8a7e-ca0b28a16a2f",`

Make sure the editor does not crash. 


