### PR TITLE
Fix bug with widget data not rendering on datasets without widgets

### DIFF
--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -141,7 +141,7 @@ function* updateWidget() {
     // Some widgets especialy maps will return an empty array or simply nothing
     // This will cause the editor to try and re render until we have resolved the data
     // As our sagas will try to refetch data we will simply not call this and let the sagas cancel
-    if (widgetData && Array.isArray(widgetData) && widgetData.length > 0) {
+    if (widgetData && widgetData.data && Array.isArray(widgetData.data) && widgetData.data.length > 0) {
       yield put(setEditor({ widgetData: widgetData.data }));
     }
   }
@@ -200,7 +200,7 @@ function* updateWidgetData() {
     // Some widgets especialy maps will return an empty array or simply nothing
     // This will cause the editor to try and re render until we have resolved the data
     // As our sagas will try to refetch data we will simply not call this and let the sagas cancel themself
-    if (widgetData && Array.isArray(widgetData) && widgetData.length > 0) {
+    if (widgetData && widgetData.data && Array.isArray(widgetData.data) && widgetData.data.length > 0) {
       yield put(setEditor({ widgetData: widgetData.data }));
     }
 


### PR DESCRIPTION
## Testing 

1. make sure widgets with "default widget render" just using the one thats in the playground by default is fine
2. Make sure previous hotfix still does not crash the editor by setting this dataset: `b82eab85-0fee-4212-8a7e-ca0b28a16a2f`
3. Make sure datasets without any default widget works, import this dataset `852f2275-91a8-4500-9f10-89880dc53f22` and set columns to show a widget

