### PR TITLE
Add the multi-line chart back

### DIFF
--- a/src/packages/core/src/charts/line-multi.ts
+++ b/src/packages/core/src/charts/line-multi.ts
@@ -1,3 +1,5 @@
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
 import { Charts, Vega, Generic, Widget } from "@widget-editor/types";
 
 import ChartsCommon from './chart-common';
@@ -5,12 +7,13 @@ import ParseSignals from './parse-signals';
 
 import { sqlFields } from "../helpers/wiget-helper/constants";
 
-export default class Line extends ChartsCommon implements Charts.Line {
+export default class MultiLine extends ChartsCommon implements Charts.Line {
   configuration: any;
   editor: any;
   schema: Vega.Schema;
   widgetConfig: Widget.Payload;
   widgetData: Generic.ObjectPayload;
+  colorField: string;
 
   constructor(
     configuration: any,
@@ -18,7 +21,8 @@ export default class Line extends ChartsCommon implements Charts.Line {
     schema: Vega.Schema,
     widgetConfig: Widget.Payload,
     widgetData: Generic.ObjectPayload,
-    scheme: any
+    scheme: any,
+    colorField: string,
   ) {
     super(configuration, editor, widgetData, scheme);
     this.configuration = configuration;
@@ -26,6 +30,7 @@ export default class Line extends ChartsCommon implements Charts.Line {
     this.schema = schema;
     this.widgetConfig = widgetConfig;
     this.widgetData = widgetData;
+    this.colorField = colorField;
 
     this.generateSchema();
     this.setGenericSettings();
@@ -40,10 +45,7 @@ export default class Line extends ChartsCommon implements Charts.Line {
       data: this.bindData(),
       interaction_config: this.interactionConfig(),
       config: this.resolveScheme(),
-      autosize: {
-        type: "fit",
-        contains: "padding",
-      },
+      legend: this.setLegend(),
       signals: [
         {
           name: "hover",
@@ -99,6 +101,12 @@ export default class Line extends ChartsCommon implements Charts.Line {
               format: '.2s',
             },
             {
+              column: "datum.color",
+              property: "color",
+              type: "string",
+              format: ".2f"
+            },
+            {
               column: "x",
               property: this.resolveName('x'),
               type: this.configuration.category?.type || 'string',
@@ -130,45 +138,79 @@ export default class Line extends ChartsCommon implements Charts.Line {
         zero: true,
         domain: { data: "table", field: sqlFields.category },
       },
+      {
+        name: "color",
+        type: "ordinal",
+        range: this.scheme.category,
+        domain: { data: "table", field: "color" }
+      },
     ];
   }
 
   setMarks() {
     return [
       {
-        name: "lines",
-        interactive: false,
-        type: "line",
-        from: { data: "table" },
-        encode: {
-          enter: {
-            x: { scale: "x", field: "x" },
-            y: { scale: "y", field: "y" },
-            strokeCap: { value: "round" },
-            strokeWidth: { value: 2 },
-            strokeJoin: { value: "round" },
-          },
+        type: "group",
+        from: {
+          facet: {
+            data: "table",
+            name: "facet",
+            groupby: "color"
+          }
         },
+        "marks": [
+          {
+            name: "lines",
+            interactive: false,
+            type: "line",
+            from: { data: "facet" },
+            encode: {
+              enter: {
+                x: { scale: "x", field: "x" },
+                y: { scale: "y", field: "y" },
+                stroke: { scale: "color", field: "color" },
+                strokeCap: { value: "round" },
+                strokeWidth: { value: 2 },
+                strokeJoin: { value: "round" },
+              },
+            },
+          },
+          {
+            interactive: false,
+            type: "symbol",
+            from: { data: "dots" },
+            encode: {
+              enter: {
+                x: { scale: "x", field: "x" },
+                y: { scale: "y", field: "y" },
+                fill: { scale: "color", field: "color" },
+              },
+              update: {
+                opacity: { value: 1 },
+              },
+            },
+          },
+        ]
       },
       {
         name: "points",
         interactive: false,
         type: "symbol",
-        from: { data: "dots" },
+        from: { data: "table" },
         encode: {
           enter: {
             x: { scale: "x", field: "x" },
             y: { scale: "y", field: "y" }
           },
           update: {
-            opacity: { value: 1 },
+            opacity: { value: 0 },
           },
         },
       },
       {
         name: "cell",
         type: "path",
-        from: { data: "lines" },
+        from: { data: "points" },
         transform: [
           {
             type: "voronoi",
@@ -248,10 +290,32 @@ export default class Line extends ChartsCommon implements Charts.Line {
         transform: [
           {
             type: "filter",
-            expr: "hover && hover.datum.x === datum.x",
+            expr: "hover && hover.datum.x === datum.x && hover.datum.color === datum.color",
           },
         ],
       },
+    ];
+  }
+
+  setLegend() {
+    const scheme = this.resolveScheme();
+
+    if (!this.widgetData) {
+      return null;
+    }
+
+    const colorValuesOrder = [...new Set(this.widgetData.map((d: any) => d.color))];
+    const getColor = d => scheme.range.category20[colorValuesOrder.indexOf(d.color)];
+    const values = sortBy(uniqBy(this.widgetData, 'color'), ['color'], ['asc'])
+      .map((d: any) => ({ label: d.color, value: getColor(d), type: 'string' }));
+
+    return [
+      {
+        type: 'color',
+        label: null,
+        shape: 'square',
+        values,
+      }
     ];
   }
 

--- a/src/packages/core/src/charts/line-multi.ts
+++ b/src/packages/core/src/charts/line-multi.ts
@@ -305,7 +305,7 @@ export default class MultiLine extends ChartsCommon implements Charts.Line {
     }
 
     const colorValuesOrder = [...new Set(this.widgetData.map((d: any) => d.color))];
-    const getColor = d => scheme.range.category20[colorValuesOrder.indexOf(d.color)];
+    const getColor = d => scheme.range.category20[colorValuesOrder.indexOf(d.color) % scheme.range.category20.length];
     const values = sortBy(uniqBy(this.widgetData, 'color'), ['color'], ['asc'])
       .map((d: any) => ({ label: d.color, value: getColor(d), type: 'string' }));
 

--- a/src/packages/core/src/services/vega.ts
+++ b/src/packages/core/src/services/vega.ts
@@ -10,6 +10,7 @@ import BarsHorizontal from "../charts/bars-horizontal";
 import GroupedBarsHorizontal from "../charts/bars-grouped-horizontal";
 import BarsStackedHorizontal from "../charts/bars-stacked-horizontal";
 import Line from "../charts/line";
+import MultiLine from "../charts/line-multi";
 import Scatter from "../charts/scatter";
 
 import { SUPPORTED_CHARTS } from "../charts/constants";
@@ -196,14 +197,26 @@ export default class VegaService implements Charts.Service {
     }
 
     if (chartType === "line") {
-      chart = new Line(
-        this.configuration,
-        this.editor,
-        this.schema,
-        this.widgetConfig,
-        data,
-        this.scheme
-      ).getChart();
+      if (this.configuration.color?.identifier) {
+        chart = new MultiLine(
+          this.configuration,
+          this.editor,
+          this.schema,
+          this.widgetConfig,
+          data,
+          this.scheme,
+          this.configuration.color.identifier
+        ).getChart();
+      } else {
+        chart = new Line(
+          this.configuration,
+          this.editor,
+          this.schema,
+          this.widgetConfig,
+          data,
+          this.scheme
+        ).getChart();
+      }
     }
 
     if (chartType === "scatter") {

--- a/src/playground/widget-editor/src/modules/editor-options/initial-state.js
+++ b/src/playground/widget-editor/src/modules/editor-options/initial-state.js
@@ -2,7 +2,7 @@ export default {
   authToken: "",
   optionsOpen: false,
   compactMode: false,
-  widget: null,
+  widget: undefined,
   theme: { color: "#C32D7B" },
-  dataset: "20cc5eca-8c63-4c41-8e8e-134dcf1e6d76",
+  dataset: "852f2275-91a8-4500-9f10-89880dc53f22",
 };


### PR DESCRIPTION
This PR adds the multi-line chart back.

<p align="center">
<img width="656" alt="Line chart with 3 lines: one yellow, and two blue (different shade)" src="https://user-images.githubusercontent.com/6073968/86894600-2fd47b00-c0fb-11ea-8110-93c17348f6fd.png">
</p>

## Testing instructions

1. Open the editor with this dataset: `852f2275-91a8-4500-9f10-89880dc53f22` (don't set any widget)
2. Change the visualisation type to “Line”
3. Choose the “number” option for the value field and the “year_date” option for the category one

A line chart should be correctly displayed.

4. Choose the “category” option for the color field

You should now see 3 lines in the chart, each attached to one category (A, B or C). The legend should use the same colours.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173465263).
