### PR TITLE
Fix issue with the number filters

### DIFF
--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react";
+import React, { Suspense, useCallback } from "react";
 import styled, { css } from "styled-components";
 
 import { Accordion, AccordionSection } from "components/accordion";
@@ -100,9 +100,9 @@ const EditorOptions = ({
     patchConfiguration({ orderBy: value });
   }
 
-  const handleLimit = (value) => {
+  const handleLimit = useCallback((value) => {
     patchConfiguration({ limit: value });
-  }
+  }, [patchConfiguration]);
 
   if (!initialized || restoring) {
     return (
@@ -146,8 +146,8 @@ const EditorOptions = ({
                 {limit && (
                   <QueryLimit
                     min={0}
-                    max={500}
-                    onChange={(value) => handleLimit(value)}
+                    max={50}
+                    onChange={handleLimit}
                     label="Limit"
                     value={limit}
                   />

--- a/src/applications/widget-editor/src/components/filter/components/FilterRange/component.js
+++ b/src/applications/widget-editor/src/components/filter/components/FilterRange/component.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 
 import QueryLimit from "components/query-limit";
 
@@ -17,9 +17,9 @@ const FilterRange = ({ filter, disabled = false, setData }) => {
 
   const [minValue, maxValue] = Array.isArray(values)
     ? values
-    : (values, min, max);
+    : [min, max];
 
-  const onSetData = (values) => {
+  const onSetData = useCallback((values) => {
     let serializeValues;
     if (filter.dataType === "date") {
       serializeValues = [UTCString(values[0]), UTCString(values[1])];
@@ -27,25 +27,7 @@ const FilterRange = ({ filter, disabled = false, setData }) => {
       serializeValues = values;
     }
     setData(serializeValues, filter.id, TYPE_RANGE);
-  };
-
-  const handleOnChangeValue = (value, key = "maxValue") => {
-    let newValues;
-
-    if (filter.dataType === "date") {
-      newValues =
-        key === "maxValue"
-          ? [ToUTCString(minValue), ToUTCString(value)]
-          : [ToUTCString(value), ToUTCString(maxValue)];
-    } else {
-      newValues =
-        key === "maxValue"
-          ? [minValue, Number(value)]
-          : [Number(value), maxValue];
-    }
-
-    setData(newValues, filter.id, TYPE_RANGE);
-  };
+  }, [filter, setData]);
 
   if (filter.dataType === "date") {
     return (
@@ -56,8 +38,7 @@ const FilterRange = ({ filter, disabled = false, setData }) => {
         max={max}
         disabled={disabled}
         value={[UTCString(minValue), UTCString(maxValue)]}
-        onChange={(value) => onSetData(value)}
-        handleOnChangeValue={handleOnChangeValue}
+        onChange={onSetData}
       />
     );
   }
@@ -69,8 +50,7 @@ const FilterRange = ({ filter, disabled = false, setData }) => {
       max={max}
       disabled={disabled}
       value={[minValue, maxValue]}
-      onChange={(value) => onSetData(value)}
-      handleOnChangeValue={handleOnChangeValue}
+      onChange={onSetData}
     />
   );
 };

--- a/src/applications/widget-editor/src/components/query-limit/component.js
+++ b/src/applications/widget-editor/src/components/query-limit/component.js
@@ -101,7 +101,7 @@ const QueryLimit = ({
                   step={isFloatingPoint ? 0.1 : 1}
                   value={isDouble ? [minValue, maxValue] : maxValue}
                   defaultValue={isDouble ? min : [min, max]}
-                  onChange={(value) => setLocalValue({ value, key: null })}
+                  onChange={(value) => setLocalValue({ value })}
                 />
               </RangeWrapper>
             </FlexController>
@@ -114,7 +114,7 @@ const QueryLimit = ({
                 type={dateType ? "date" : "number"}
                 name="options-limit-min"
                 onChange={(e) =>
-                  setLocalValue({ value: e.target.value, key: "minValue" })
+                  setLocalValue({ value: [+e.target.value, maxValue] })
                 }
               />
             </FlexController>
@@ -129,7 +129,7 @@ const QueryLimit = ({
                 type={dateType ? "date" : "number"}
                 name="options-limit-max"
                 onChange={(e) =>
-                  setLocalValue({ value: e.target.value, key: "maxValue" })
+                  setLocalValue({ value: [minValue, +e.target.value] })
                 }
               />
             </FlexController>


### PR DESCRIPTION
This PR fixes an issue where setting number filters might crash or freeze the editor.

Note that the date filters, which use the same components, are also not working, but are tracked in a [different task](https://www.pivotaltracker.com/story/show/173890050).

## Testing instructions

1. Open the playground
2. Select this dataset from the UI: “Forest Sector Economic Contribution”
3. Add new new filter using the field “Forest Sector Employment as Share of Total Workforce”
4. Move the handles of the slider

After about 1s, the chart must be updated.

5. Change the filter values using the two inputs

Again, after about 1s, the chart must be updated.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173848151).
