### PR TITLE
Prevent the editor from setting a widget by itself

### DIFF
--- a/src/adapters/rw-adapter/src/index.ts
+++ b/src/adapters/rw-adapter/src/index.ts
@@ -84,7 +84,7 @@ export default class RwAdapter implements Adapter.Service {
 
   async getDataset() {
     const { applications, env, locale } = this.config.getConfig();
-    const includes = "metadata,vocabulary,widget,layer";
+    const includes = "metadata,vocabulary,layer";
 
     const url = tags.oneLineTrim`
       ${this.endpoint}
@@ -108,9 +108,6 @@ export default class RwAdapter implements Adapter.Service {
       ...dataset,
       attributes: {
         ...dataset.attributes,
-        widget: dataset.attributes.widget.filter(
-          (w) => !!w.attributes.published
-        ),
       },
     };
 
@@ -155,11 +152,7 @@ export default class RwAdapter implements Adapter.Service {
     const { applications, env, locale } = this.config.getConfig();
     const includes = "metadata";
 
-    const resolveWidgetId = !widgetId
-      ? this.widgetService.fromDataset(dataset)?.id
-      : widgetId;
-
-    if (!resolveWidgetId) {
+    if (!widgetId) {
       return {
         ...defaultWidget,
         attributes: {
@@ -173,7 +166,7 @@ export default class RwAdapter implements Adapter.Service {
     const url = tags.oneLineTrim`
       ${this.endpoint}
       /widget/
-      ${resolveWidgetId}?
+      ${widgetId}?
       ${applications.join(",")}
       &env=${env}
       &language=${locale}

--- a/src/packages/core/src/services/widget.ts
+++ b/src/packages/core/src/services/widget.ts
@@ -9,13 +9,6 @@ export default class WidgetService implements Widget.Service {
     this.config = config;
   }
 
-  fromDataset(dataset: Dataset.Payload): Widget.Payload {
-    return find(
-      dataset.attributes?.widget,
-      (widget) => !!widget.attributes.defaultEditableWidget
-    );
-  }
-
   async fetchWidget(url: string): Promise<Widget.Payload> {
     try {
       const response = await fetch(url);

--- a/src/packages/types/src/widget.ts
+++ b/src/packages/types/src/widget.ts
@@ -22,6 +22,5 @@ export interface Payload {
 }
 
 export interface Service {
-  fromDataset(dataset: object): object;
   fetchWidget(widgetId: Id): Promise<Payload>;
 }


### PR DESCRIPTION
If no `widgetId` prop is passed to the widget-editor, then no widget should be selected or be editable. v2, by default, would restore the default widget of the dataset. This PR removes this behaviour.

## Testing instructions

1. Open the playground
2. Select this dataset from the UI: “Forest Sector Economic Contribution”

You must not see any visualisation.

3. Set the category and value fields to create a visualisation

Your visualisation must render correctly.

## Pivotal Tracker

Not tracked.
