### PR TITLE
Fix a bug where the limit field could disappear

### DIFF
--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -143,7 +143,7 @@ const EditorOptions = ({
                 <OrderValues
                   onChange={(value) => handleOrderBy(value)}
                 />
-                {limit && (
+                {limit !== undefined && limit !== null && (
                   <QueryLimit
                     min={0}
                     max={50}


### PR DESCRIPTION
This PR fixes an issues where the limit field could disappear if its value would be set to 0.

## Testing instructions

1. Build any kind of chart
2. Using the slider, set the row limit to 0

The slider and input must not disappear.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173900968).
