### PR TITLE
Fix a bug where the user wouldn't be able to reset the value aggregation

### DIFF
--- a/src/applications/widget-editor/src/components/widget-info/component.js
+++ b/src/applications/widget-editor/src/components/widget-info/component.js
@@ -13,17 +13,12 @@ import CreatableSelect from "react-select/creatable";
 import { InputStyles } from "./style";
 
 import VALUE_FORMAT_OPTIONS from "@widget-editor/shared/lib/constants/value-formats";
-import aggregations from "@widget-editor/shared/lib/constants/aggregations";
+import AGGREGATION_OPTIONS from "@widget-editor/shared/lib/constants/aggregations";
 
 class WidgetInfo extends React.Component {
   constructor(props) {
     super(props);
     this.state = this.stateFromProps(props.configuration);
-
-    this.aggregationOptions = aggregations.map((agg) => ({
-      value: agg.toUpperCase(),
-      label: agg.charAt(0).toUpperCase() + agg.slice(1),
-    }));
 
     this.setValueFormat = this.setValueFormat.bind(this);
     this.setAggregation = this.setAggregation.bind(this);
@@ -201,11 +196,11 @@ class WidgetInfo extends React.Component {
           <InputGroup>
             <FormLabel htmlFor="options-title">Value aggregation</FormLabel>
             <Select
-              value={this.aggregationOptions.find(
+              value={AGGREGATION_OPTIONS.find(
                 (agg) => agg.value === aggregateFunction
               )}
               onChange={this.setAggregation}
-              options={this.aggregationOptions}
+              options={AGGREGATION_OPTIONS}
               styles={InputStyles}
             />
           </InputGroup>

--- a/src/applications/widget-editor/src/components/widget-info/component.js
+++ b/src/applications/widget-editor/src/components/widget-info/component.js
@@ -7,6 +7,7 @@ import FormLabel from "styles-common/form-label";
 import InputGroup from "styles-common/input-group";
 import Input from "styles-common/input";
 import debounce from "lodash/debounce";
+import Select from "react-select";
 import CreatableSelect from "react-select/creatable";
 
 import { InputStyles } from "./style";
@@ -199,7 +200,7 @@ class WidgetInfo extends React.Component {
         {!isMap && (
           <InputGroup>
             <FormLabel htmlFor="options-title">Value aggregation</FormLabel>
-            <CreatableSelect
+            <Select
               value={this.aggregationOptions.find(
                 (agg) => agg.value === aggregateFunction
               )}

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -14,8 +14,6 @@ import filtersHelper from "../helpers/filters";
 
 import asyncForEach from "@widget-editor/shared/lib/helpers/async-foreach";
 
-import aggregations from "@widget-editor/shared/lib/constants/aggregations";
-
 export default class FiltersService implements Filters.Service {
   sql: string;
   dataset: any;

--- a/src/packages/shared/src/constants/aggregations.js
+++ b/src/packages/shared/src/constants/aggregations.js
@@ -1,1 +1,8 @@
-export default ["none", "sum", "avg", "max", "min", "count"];
+export default [
+  { label: 'None', value: null },
+  { label: 'Sum', value: 'sum' },
+  { label: 'Average', value: 'avg' },
+  { label: 'Maximum', value: 'max' },
+  { label: 'Minimum', value: 'min' },
+  { label: 'Count', value: 'count' },
+]


### PR DESCRIPTION
The main goal of this PR is to fix an issue where the user wouldn't be able to reset the value aggregation.

Other changes include:
- Preventing the user from creating aggregations
- Setting “None” as the default option
- Displaying more user-friendly names

## Testing instructions

1. Restore this dataset: `a86d906d-9862-4783-9e30-cdb68cd808b8`
2. Use the “Country” field on the X axis
3. Use the “Capacity” field on the Y axis

You should see multiple bars for China. The default value of the aggregation field must be “None”.

4. Aggregate using the sum function

Now, only one bar is displayed for China

5. Select the “None” option of the aggregation select

You must see multiple bars for China again.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173900908).
