### PR TITLE
Fix an issue where the legend of the bar charts would be empty

### DIFF
--- a/src/packages/core/src/charts/bars-grouped-horizontal.ts
+++ b/src/packages/core/src/charts/bars-grouped-horizontal.ts
@@ -1,9 +1,9 @@
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
 import { Charts, Vega, Generic, Widget } from "@widget-editor/types";
 
 import ChartsCommon from './chart-common';
 import ParseSignals from './parse-signals';
-
-import { sqlFields } from "../helpers/wiget-helper/constants";
 
 export default class BarsHorizontal extends ChartsCommon implements Charts.Bars {
   configuration: any;
@@ -241,9 +241,6 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
     ];
   }
 
-  // FIXME: this is temporal, bar charts with a 3rd dimension (color) should be grouped bar charts
-  // This fix just displays the legend correctly while the grouped bar chart visualisation is
-  // brought back
   setLegend() {
     const scheme = this.resolveScheme();
 
@@ -251,16 +248,22 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
       return null;
     }
 
+    const colorValuesOrder = [...new Set(this.widgetData.map((d: { color: string | number }) => d.color))];
+    const colorRange = scheme.range.category20;
+    const getColor = d => colorRange[colorValuesOrder.indexOf(d.color)];
+    const values = sortBy(uniqBy(this.widgetData, 'color'), ['color'], ['asc'])
+      .map((d: { color: string | number }) => ({
+        label: d.color,
+        value: getColor(d),
+        type: 'string',
+      }));
+
     return [
       {
         type: 'color',
         label: null,
         shape: 'square',
-        values: this.widgetData.map((d: { x: string, y: number }, index) => ({
-          label: d[this.colorField],
-          value: scheme.range.category20[index % scheme.range.category20.length],
-          type: 'string',
-        }))
+        values,
       }
     ];
   }

--- a/src/packages/core/src/charts/bars-grouped.ts
+++ b/src/packages/core/src/charts/bars-grouped.ts
@@ -1,9 +1,9 @@
-import { Charts, Vega, Generic, Widget } from "@widget-editor/types";
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
+import { Charts, Vega, Generic } from "@widget-editor/types";
 
 import ChartsCommon from './chart-common';
 import ParseSignals from './parse-signals';
-
-import { sqlFields } from "../helpers/wiget-helper/constants";
 
 export default class GroupedBars extends ChartsCommon implements Charts.Bars {
   configuration: any;
@@ -241,9 +241,6 @@ export default class GroupedBars extends ChartsCommon implements Charts.Bars {
     ];
   }
 
-  // FIXME: this is temporal, bar charts with a 3rd dimension (color) should be grouped bar charts
-  // This fix just displays the legend correctly while the grouped bar chart visualisation is
-  // brought back
   setLegend() {
     const scheme = this.resolveScheme();
 
@@ -251,16 +248,22 @@ export default class GroupedBars extends ChartsCommon implements Charts.Bars {
       return null;
     }
 
+    const colorValuesOrder = [...new Set(this.widgetData.map((d: { color: string | number }) => d.color))];
+    const colorRange = scheme.range.category20;
+    const getColor = d => colorRange[colorValuesOrder.indexOf(d.color)];
+    const values = sortBy(uniqBy(this.widgetData, 'color'), ['color'], ['asc'])
+      .map((d: { color: string | number }) => ({
+        label: d.color,
+        value: getColor(d),
+        type: 'string',
+      }));
+
     return [
       {
         type: 'color',
         label: null,
         shape: 'square',
-        values: this.widgetData.map((d: { x: string, y: number }, index) => ({
-          label: d[this.colorField],
-          value: scheme.range.category20[index % scheme.range.category20.length],
-          type: 'string',
-        }))
+        values,
       }
     ];
   }

--- a/src/packages/core/src/charts/bars-stacked-horizontal.ts
+++ b/src/packages/core/src/charts/bars-stacked-horizontal.ts
@@ -1,9 +1,9 @@
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
 import { Charts, Vega, Generic, Widget } from "@widget-editor/types";
 
 import ChartsCommon from './chart-common';
 import ParseSignals from './parse-signals';
-
-import { sqlFields } from "../helpers/wiget-helper/constants";
 
 export default class BarsHorizontal extends ChartsCommon implements Charts.Bars {
   configuration: any;
@@ -210,9 +210,6 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
     ];
   }
 
-  // FIXME: this is temporal, bar charts with a 3rd dimension (color) should be grouped bar charts
-  // This fix just displays the legend correctly while the grouped bar chart visualisation is
-  // brought back
   setLegend() {
     const scheme = this.resolveScheme();
 
@@ -220,16 +217,22 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
       return null;
     }
 
+    const colorValuesOrder = [...new Set(this.widgetData.map((d: { color: string | number }) => d.color))];
+    const colorRange = scheme.range.category20;
+    const getColor = d => colorRange[colorValuesOrder.indexOf(d.color)];
+    const values = sortBy(uniqBy(this.widgetData, 'color'), ['color'], ['asc'])
+      .map((d: { color: string | number }) => ({
+        label: d.color,
+        value: getColor(d),
+        type: 'string',
+      }));
+
     return [
       {
         type: 'color',
         label: null,
         shape: 'square',
-        values: this.widgetData.map((d: { x: string, y: number }, index) => ({
-          label: d[this.colorField],
-          value: scheme.range.category20[index % scheme.range.category20.length],
-          type: 'string',
-        }))
+        values,
       }
     ];
   }

--- a/src/packages/core/src/charts/bars-stacked.ts
+++ b/src/packages/core/src/charts/bars-stacked.ts
@@ -1,9 +1,9 @@
-import { Charts, Vega, Generic, Widget } from "@widget-editor/types";
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
+import { Charts, Vega, Generic } from "@widget-editor/types";
 
 import ChartsCommon from './chart-common';
 import ParseSignals from './parse-signals';
-
-import { sqlFields } from "../helpers/wiget-helper/constants";
 
 export default class BarsStacked extends ChartsCommon implements Charts.Bars {
   configuration: any;
@@ -211,9 +211,6 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
     ];
   }
 
-  // FIXME: this is temporal, bar charts with a 3rd dimension (color) should be grouped bar charts
-  // This fix just displays the legend correctly while the grouped bar chart visualisation is
-  // brought back
   setLegend() {
     const scheme = this.resolveScheme();
 
@@ -221,16 +218,22 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
       return null;
     }
 
+    const colorValuesOrder = [...new Set(this.widgetData.map((d: { color: string | number }) => d.color))];
+    const colorRange = scheme.range.category20;
+    const getColor = d => colorRange[colorValuesOrder.indexOf(d.color)];
+    const values = sortBy(uniqBy(this.widgetData, 'color'), ['color'], ['asc'])
+      .map((d: { color: string | number }) => ({
+        label: d.color,
+        value: getColor(d),
+        type: 'string',
+      }));
+
     return [
       {
         type: 'color',
         label: null,
         shape: 'square',
-        values: this.widgetData.map((d: { x: string, y: number }, index) => ({
-          label: d[this.colorField],
-          value: scheme.range.category20[index % scheme.range.category20.length],
-          type: 'string',
-        }))
+        values,
       }
     ];
   }


### PR DESCRIPTION
This PR fixes an issue where the legend of the bar charts would be empty: the label next to the colour dots would not be displayed.

In addition, the code that would generate the legend wouldn't remove duplicate values.

## Testing instructions

1. Restore this dataset: `a86d906d-9862-4783-9e30-cdb68cd808b8`
2. Select the horizontal stacked bar chart visualisation
3. Select “Country” on the Y axis
4. Select “Capacity” on the X axis
5. Select “Fuel” in the color select

Make sure the legend displays once every fuel type and that they correspond to the colours of the visualisation.

6. Select the vertical stacked bar chart visualisation

Make the same check.

7. Select the horizontal grouped bar chart visualisation

Make the same check.

8. Select the vertical grouped bar chart visualisation

Make the same check.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173901147).
