### PR TITLE
Fix a bug preventing the user from creating filters

### DIFF
--- a/src/applications/widget-editor/src/components/filter/component.js
+++ b/src/applications/widget-editor/src/components/filter/component.js
@@ -41,7 +41,7 @@ const Filter = ({
           value: field.columnName,
           type:
             constants.ALLOWED_FIELD_TYPES.find(type => type.name === field.type)?.type ?? 'string',
-          isDisabled: usedColumns.indexOf(field.columnName) === -1,
+          isDisabled: usedColumns.indexOf(field.columnName) !== -1,
         }))
       .sort((option1, option2) => option1.label.localeCompare(option2.label))
   }, [filters, fields]);


### PR DESCRIPTION
This PR fixes a bug introduced in #83 that prevents the user from creating filters.

## Testing instructions

1. Instantiate the widget-editor with this dataset: `852f2275-91a8-4500-9f10-89880dc53f22`
2. Add a new filter

Make sure you can select any of the columns.

3. Instantiate the editor with this widget: `6116d7ab-2a13-4ffe-b663-f4136ff74f17` (dataset: `082e2262-c58e-46a0-b6b7-56083cfcbd34`)
3. Add a new filter

Make sure you cannot create a filter with the columns already used by the other filters.

## Pivotal Tracker

Not tracked.