### PR TITLE
Fix a bug preventing users from creating maps with raster datasets

### DIFF
--- a/src/applications/renderer/src/components/renderer/component.js
+++ b/src/applications/renderer/src/components/renderer/component.js
@@ -70,10 +70,7 @@ const Renderer = ({
     <StyledContainer compact={compact}>
       {!widgetConfig && initialized && (
         <Suspense fallback={<div>Loading...</div>}>
-          <SelectChart
-            advanced={editor.advanced}
-            rasterOnly={configuration.rasterOnly}
-          />
+          <SelectChart advanced={editor.advanced} />
         </Suspense>
       )}
 

--- a/src/applications/renderer/src/components/select-chart/component.js
+++ b/src/applications/renderer/src/components/select-chart/component.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import find from "lodash/find";
-import filter from "lodash/filter";
 import { Button } from "@widget-editor/shared";
 import Select from "react-select";
 import ChartMenu from "./components/ChartMenu";
@@ -21,8 +21,6 @@ const SelectChart = ({
   theme,
   advanced,
   setTheme,
-  rasterOnly,
-  disabledFeatures,
 }) => {
   const [selected, setSelected] = useState(find(options, { chartType }));
 
@@ -54,16 +52,8 @@ const SelectChart = ({
     });
   };
 
-  const filterOutDisabledCharts = filter(
-    options,
-    (o) => disabledFeatures.indexOf(o.value) === -1
-  );
-
   return (
-    <StyledContainer
-      rasterOnly={rasterOnly}
-      isCompact={isCompact || forceCompact}
-    >
+    <StyledContainer isCompact={isCompact || forceCompact}>
       {advanced && (
         <StyledSelectBox isCompact={isCompact || forceCompact}>
           <Select
@@ -80,14 +70,14 @@ const SelectChart = ({
         </StyledSelectBox>
       )}
 
-      {!advanced && !rasterOnly && (
+      {!advanced && (
         <StyledSelectBox isCompact={isCompact || forceCompact}>
           <Select
             onChange={handleChange}
             onMenuOpen={() => setIsOpenMenu(true)}
             onMenuClose={() => setIsOpenMenu(false)}
             value={selected}
-            options={filterOutDisabledCharts}
+            options={options}
             styles={InputStyles}
             components={{ Menu: ChartMenu }}
             menuIsOpen={isOpenMenu}
@@ -101,6 +91,13 @@ const SelectChart = ({
       )}
     </StyledContainer>
   );
+};
+
+SelectChart.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })),
 };
 
 export default SelectChart;

--- a/src/applications/renderer/src/components/select-chart/index.js
+++ b/src/applications/renderer/src/components/select-chart/index.js
@@ -2,16 +2,16 @@ import { redux } from "@widget-editor/shared";
 
 import { patchConfiguration } from "@widget-editor/shared/lib/modules/configuration/actions";
 import { setTheme } from "@widget-editor/shared/lib/modules/theme/actions";
+import { selectChartOptions } from "@widget-editor/shared/lib/modules/configuration/selectors";
 
 // Components
 import SelectChartComponent from "./component";
 
 export default redux.connectState(
   (state) => ({
-    options: state.configuration.availableCharts,
+    options: selectChartOptions(state),
     chartType: state.configuration.chartType,
     theme: state.theme,
-    disabledFeatures: state.editor.disabledFeatures,
   }),
   { patchConfiguration, setTheme }
 )(SelectChartComponent);

--- a/src/applications/renderer/src/components/select-chart/style.js
+++ b/src/applications/renderer/src/components/select-chart/style.js
@@ -8,14 +8,6 @@ export const StyledContainer = styled.div`
       display: flex;
       align-items: center;
     `}
-
-  ${(props) =>
-    props.rasterOnly &&
-    !props.isCompact &&
-    !props.forceCompact &&
-    css`
-      margin: 0;
-    `}
 `;
 
 export const StyledSelectBox = styled.div`

--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -47,11 +47,11 @@ function* preloadData() {
     };
 
     const datasetType = editor?.dataset?.attributes?.type;
-    const rasterOnly = datasetType && datasetType.match(/raster/);
+    const rasterOnly = !!(datasetType && datasetType.match(/raster/));
 
-    const isMap =
-      editor?.widget?.attributes?.widgetConfig?.paramsConfig
-        ?.visualizationType === "map";
+    // If the dataset is raster, only maps can be done right now
+    const isMap = rasterOnly
+      || editor?.widget?.attributes?.widgetConfig?.paramsConfig?.visualizationType === "map";
 
     const paramsConfig = widgetConfig.hasOwnProperty("paramsConfig")
       ? widgetConfig.paramsConfig
@@ -70,6 +70,7 @@ function* preloadData() {
       description,
       caption,
       rasterOnly,
+      visualizationType: isMap ? "map" : "chart",
       ...(isMap ? { chartType: "map" } : {}),
       map: mapSpecifics,
     };

--- a/src/packages/shared/src/modules/configuration/selectors.js
+++ b/src/packages/shared/src/modules/configuration/selectors.js
@@ -1,0 +1,23 @@
+import { createSelector } from "reselect";
+
+import { selectDisabledFeatures } from "../editor/selectors";
+
+const selectAvailableCharts = state => state.configuration.availableCharts;
+const selectRasterOnly = state => state.configuration.rasterOnly;
+
+export const selectChartOptions = createSelector(
+  [selectAvailableCharts, selectRasterOnly, selectDisabledFeatures],
+  (availableCharts, isRaster, disabledFeatures) => {
+    let res = availableCharts;
+
+    if (isRaster) {
+      // Currently, only map widgets can be created with raster datasets
+      res = res.filter(option => option.value === 'map');
+    }
+
+    // We filter out the visualization that are disabled by the host app
+    res = res.filter(option => disabledFeatures.indexOf(option.value) === -1);
+
+    return res;
+  },
+);

--- a/src/packages/shared/src/modules/editor/selectors.js
+++ b/src/packages/shared/src/modules/editor/selectors.js
@@ -1,0 +1,1 @@
+export const selectDisabledFeatures = state => state.editor.disabledFeatures;


### PR DESCRIPTION
This PR fixes a bug where the widget-editor wouldn't display any visualisation options when instantiating it with a raster dataset.

## Testing instructions

1. Instantiate the editor with this dataset: 4d3d6f25-6e66-426f-be9b-32777b4755cc

Make sure only the “Map” option is available and that it is selected by default.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/174213724).
