### PR TITLE
Fix an issue where some map widgets crash the editor

### DIFF
--- a/src/adapters/rw-adapter/src/index.ts
+++ b/src/adapters/rw-adapter/src/index.ts
@@ -277,13 +277,8 @@ export default class RwAdapter implements Adapter.Service {
               boundaries: editorState.configuration.map?.basemap?.boundaries || false,
             },
           }
-          : {
-            basemapLayers: {
-              basemap: "dark",
-              labels: "Dark",
-              boundaries: false,
-            },
-          }),
+          : {}
+        ),
         paramsConfig: {
           visualizationType: editorState.configuration.visualizationType,
           layer: editorState.configuration.layer,

--- a/src/applications/widget-editor/src/components/map-info/basemaps.js
+++ b/src/applications/widget-editor/src/components/map-info/basemaps.js
@@ -9,7 +9,7 @@ const serializeSelection = (o) => ({
 });
 
 const BasemapSelection = ({ configuration, basemaps, onSetBasemap }) => {
-  const selectedBasemap = configuration?.map.basemap?.basemap || "dark";
+  const selectedBasemap = configuration.map.basemap.basemap;
   const selectedOption = serializeSelection(basemaps[selectedBasemap]);
   const serialize = Object.keys(basemaps).map((basemap) =>
     serializeSelection(basemaps[basemap])

--- a/src/applications/widget-editor/src/components/map-info/labels.js
+++ b/src/applications/widget-editor/src/components/map-info/labels.js
@@ -9,7 +9,7 @@ const serializeSelection = (o) => ({
 });
 
 const LabelsSelection = ({ configuration, labels, onSetLabel }) => {
-  const selectedLabel = configuration?.map?.basemap?.labels || "none";
+  const selectedLabel = configuration.map.basemap.labels;
   const selectedOption = serializeSelection(labels[selectedLabel]);
   const serialize = Object.keys(labels).map((basemap) =>
     serializeSelection(labels[basemap])

--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -1,6 +1,7 @@
 import { takeLatest, put, select, all, fork, call, take, cancel } from "redux-saga/effects";
 import { constants } from "@widget-editor/core";
 
+import { LABELS, BASEMAPS } from "@widget-editor/map/src/constants";
 import { setConfiguration, resetConfiguration } from "@widget-editor/shared/lib/modules/configuration/actions";
 import { setEditor, resetEditor } from "@widget-editor/shared/lib/modules/editor/actions";
 
@@ -39,8 +40,24 @@ function* preloadData() {
         ? { bbox: widgetConfig.bbox }
         : {}),
       ...(widgetConfig.hasOwnProperty("basemapLayers")
-        ? { basemap: widgetConfig.basemapLayers }
-        : {}),
+        ? {
+          basemap: {
+            basemap: Object.keys(BASEMAPS).indexOf(widgetConfig.basemapLayers.basemap) !== -1
+              ? widgetConfig.basemapLayers.basemap
+              : "dark",
+            labels: Object.keys(LABELS).indexOf(widgetConfig.basemapLayers.labels) !== -1
+              ? widgetConfig.basemapLayers.labels
+              : "none",
+            boundaries: typeof widgetConfig.basemapLayers.boundaries === 'boolean'
+              ? widgetConfig.basemapLayers.boundaries
+              : false,
+          }
+        }
+        : {
+          basemap: "dark",
+          labels: "none",
+          boundaries: false,
+        }),
       ...(widgetConfig.hasOwnProperty("zoom")
         ? { zoom: widgetConfig.zoom }
         : {}),


### PR DESCRIPTION
**⚠️ This is a hotfix.** Once approved, it must be merged in `master` and `develop`.

---

This PR fixes an issue where some map widgets would crash the editor because they would be serialised with a labels option that isn't available in the editor.

Essentially, if the user would save a map widget, without changing its labels settings first, the editor would save a default value, `'Dark'`, which doesn't match any option (it should be `'dark'`).

This PR does 2 things:
1. The serialisation process doesn't assign any default values anymore
2. The restoring process checks if the serialised options make sense or else removes them

In case an option is invalid or it is not provided, a default option is set in the store (see `src/applications/widget-editor/src/sagas/editor/index.js`). Previously, the default value would be set in the application (in the `src/applications/widget-editor/src/components/map-info/*.js` components) and thus wouldn't be serialised. This PR addresses this issue, as mentioned before, by setting the default options in the store.

## Testing instructions

1. Instantiate the editor with this widget: `8f35300c-9c89-4d17-bf72-72abdb9597fc` (dataset: `5e156d22-7f84-4cd2-9724-c1a519a83e0a`)

The editor mustn't crash and the map must to restored.

## Pivotal Tracker

Not tracked. Reported by PM.
