### PR TITLE
Fix a bug that would crash the editor

### DIFF
--- a/src/packages/core/src/services/widget.ts
+++ b/src/packages/core/src/services/widget.ts
@@ -12,12 +12,7 @@ export default class WidgetService implements Widget.Service {
   async fetchWidget(url: string): Promise<Widget.Payload> {
     try {
       const response = await this.adapter.prepareRequest(url);
-
-      if (response.status >= 400) {
-        throw new Error(response.statusText);
-      }
-
-      return await response.json();
+      return response.data;
     } catch (err) {
       throw new Error(err);
     }


### PR DESCRIPTION
During the axios migration #76, the widget service has been left out. The remaining code would crash the editor when restoring a widget. This PR makes the changes that were left out.

## Testing instructions

Restore any widget. The editor must not crash.

## Pivotal Tracker

Not tracked.
