### PR TITLE
Improve the settings UI

### DIFF
--- a/src/applications/renderer/package.json
+++ b/src/applications/renderer/package.json
@@ -19,7 +19,6 @@
     "@widget-editor/types": "^2.2.24",
     "babel-plugin-styled-components": "^1.10.6",
     "lodash": "^4.17.15",
-    "react-resize-detector": "^4.2.1",
     "react-select": "^3.0.8",
     "react-slick": "^0.25.2",
     "react-slider": "^1.0.2",

--- a/src/applications/widget-editor/package.json
+++ b/src/applications/widget-editor/package.json
@@ -21,7 +21,6 @@
     "lodash": "^4.17.15",
     "prismjs": "^1.20.0",
     "rc-slider": "^9.2.4",
-    "react-resize-detector": "^4.2.1",
     "react-select": "^3.0.8",
     "react-simple-code-editor": "^0.11.0",
     "react-slick": "^0.25.2",

--- a/src/applications/widget-editor/src/components/accordion/component.js
+++ b/src/applications/widget-editor/src/components/accordion/component.js
@@ -1,5 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
-import ReactResizeDetector from "react-resize-detector";
+import React, { useState, useCallback } from "react";
 
 import {
   StyledAccordionSection,
@@ -9,44 +8,21 @@ import {
 } from "./style";
 
 export const AccordionSection = ({ title, openDefault, children }) => {
-  const contentRef = useRef({});
-  const [outerHeight, setOuterHeight] = useState(0);
-  const [isOpen, setOpen] = useState(false);
+  const [isOpen, setOpen] = useState(openDefault);
 
-  const clickToTitle = () => {
-    setOpen(!isOpen);
-    const panel = contentRef.current;
-    if (panel) {
-      const height = outerHeight ? 0 : panel.scrollHeight;
-      setOuterHeight(height);
-    }
-  };
-
-  const updateHeight = () => {
-    const panel = contentRef.current;
-    if (panel && panel.scrollHeight > 0 && isOpen) {
-      const height = panel.scrollHeight;
-      setOuterHeight(height);
-    }
-  };
-
-  useEffect(() => {
-    setTimeout(() => (openDefault ? clickToTitle() : null), 0);
-  }, []);
+  const onClickTitle = useCallback(() => setOpen(o => !o), [setOpen]);
 
   return (
     <StyledAccordionSection>
       <StyledAccordionButton
         type="button"
         role="button"
-        onClick={() => clickToTitle()}
+        onClick={onClickTitle}
       >
         {title}
       </StyledAccordionButton>
-      <StyledAccordionContent ref={contentRef} scrollHeight={outerHeight}>
-        <ReactResizeDetector handleHeight skipOnMount onResize={updateHeight}>
-          <div>{children}</div>
-        </ReactResizeDetector>
+      <StyledAccordionContent isOpen={isOpen}>
+        {children}
       </StyledAccordionContent>
     </StyledAccordionSection>
   );

--- a/src/applications/widget-editor/src/components/accordion/component.js
+++ b/src/applications/widget-editor/src/components/accordion/component.js
@@ -4,10 +4,11 @@ import {
   StyledAccordionSection,
   StyledAccordionContent,
   StyledAccordionButton,
+  StyledIcon,
   StyledAccordion,
 } from "./style";
 
-export const AccordionSection = ({ title, openDefault, children }) => {
+export const AccordionSection = ({ title, openDefault, themeColor, children }) => {
   const [isOpen, setOpen] = useState(openDefault);
 
   const onClickTitle = useCallback(() => setOpen(o => !o), [setOpen]);
@@ -19,6 +20,7 @@ export const AccordionSection = ({ title, openDefault, children }) => {
         role="button"
         onClick={onClickTitle}
       >
+        <StyledIcon isOpen={isOpen} themeColor={themeColor} />
         {title}
       </StyledAccordionButton>
       <StyledAccordionContent isOpen={isOpen}>

--- a/src/applications/widget-editor/src/components/accordion/index.js
+++ b/src/applications/widget-editor/src/components/accordion/index.js
@@ -1,3 +1,10 @@
-// Components
-export * from "./component";
+import { connectState } from "@widget-editor/shared/lib/helpers/redux";
 
+// Components
+import { AccordionSection as UnconnectedAccordionSection } from "./component";
+
+export { Accordion } from "./component";
+
+export const AccordionSection = connectState(
+  state => ({ themeColor: state.theme.color })
+)(UnconnectedAccordionSection);

--- a/src/applications/widget-editor/src/components/accordion/style.js
+++ b/src/applications/widget-editor/src/components/accordion/style.js
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 
+import { AccordionArrow } from "@widget-editor/shared"
+
 export const StyledAccordion = styled.div`
   width: 100%;
   padding-top: 24px;
@@ -29,16 +31,15 @@ export const StyledAccordionButton = styled.button`
   border: none;
   background: none;
   outline: none;
-  &:before {
-    content: " ";
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: #c32d7b;
-    position: absolute;
-    left: 0;
-    top: 8px;
-  }
+`;
+
+export const StyledIcon = styled(AccordionArrow)`
+  position: absolute;
+  left: 0;
+  top: 5px;
+  stroke: ${props => props.themeColor};
+  transform: ${props => props.isOpen ? 'rotate(0)' : 'rotate(-90deg)'};
+  transition: transform 0.2s ease-out;
 `;
 
 export const StyledAccordionSection = styled.div`

--- a/src/applications/widget-editor/src/components/accordion/style.js
+++ b/src/applications/widget-editor/src/components/accordion/style.js
@@ -8,12 +8,12 @@ export const StyledAccordion = styled.div`
 
 export const StyledAccordionContent = styled.div`
   display: "block";
-  max-height: ${(props) => props.scrollHeight + "px" || "0"};
-  overflow-y: ${(props) => (props.scrollHeight ? "visible" : "hidden")};
-  transition: all 0.2s ease-out;
+  max-height: ${props => props.isOpen ? 'none' : 0};
+  overflow-y: ${props => props.isOpen ? 'visible' : 'hidden'};
+  transition: padding 0.2s ease-out;
   padding-left: 24px;
-  padding-top: ${(props) => (props.scrollHeight ? "18px" : "0" || "0")};
-  padding-bottom: ${(props) => (props.scrollHeight ? "18px" : "0" || "0")};
+  padding-top: ${(props) => (props.isOpen ? "18px" : 0)};
+  padding-bottom: ${(props) => (props.isOpen ? "18px" : 0)};
 `;
 
 export const StyledAccordionButton = styled.button`

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -198,7 +198,7 @@ const EditorOptions = ({
         {!isMap && (
           <Tab label="Visual style">
             <Accordion>
-              {disabledFeatures.indexOf("typogrophy") === -1 && (
+              {disabledFeatures.indexOf("typography") === -1 && (
                 <AccordionSection title="Typography">
                   <Suspense fallback={<div>Loading...</div>}>
                     <Typography />
@@ -207,7 +207,10 @@ const EditorOptions = ({
               )}
 
               {disabledFeatures.indexOf("theme-selection") === -1 && (
-                <AccordionSection title="Color">
+                <AccordionSection
+                  title="Color"
+                  openDefault={disabledFeatures.indexOf("typography") !== -1}
+                >
                   <Suspense fallback={<div>Loading...</div>}>
                     <ColorShemes />
                   </Suspense>

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -180,37 +180,44 @@ const EditorOptions = ({
                 </Suspense>
               </AccordionSection>
             )}
-            {isMap && (
-              <AccordionSection title="Map configuration" openDefault>
+          </Accordion>
+        </Tab>
+        
+        {isMap && (
+          <Tab label="Map">
+            <Accordion>
+              <AccordionSection title="Configuration" openDefault>
                 <Suspense fallback={<div>Loading...</div>}>
                   <MapInfo />
                 </Suspense>
               </AccordionSection>
-            )}
-          </Accordion>
-        </Tab>
+            </Accordion>
+          </Tab>
+        )}
 
-        <Tab label="Visual style">
-          <Accordion>
-            {disabledFeatures.indexOf("typogrophy") === -1 && (
-              <AccordionSection title="Typography">
-                <Suspense fallback={<div>Loading...</div>}>
-                  <Typography />
-                </Suspense>
-              </AccordionSection>
-            )}
+        {!isMap && (
+          <Tab label="Visual style">
+            <Accordion>
+              {disabledFeatures.indexOf("typogrophy") === -1 && (
+                <AccordionSection title="Typography">
+                  <Suspense fallback={<div>Loading...</div>}>
+                    <Typography />
+                  </Suspense>
+                </AccordionSection>
+              )}
 
-            {disabledFeatures.indexOf("theme-selection") === -1 && (
-              <AccordionSection title="Color">
-                <Suspense fallback={<div>Loading...</div>}>
-                  <ColorShemes />
-                </Suspense>
-              </AccordionSection>
-            )}
-          </Accordion>
-        </Tab>
+              {disabledFeatures.indexOf("theme-selection") === -1 && (
+                <AccordionSection title="Color">
+                  <Suspense fallback={<div>Loading...</div>}>
+                    <ColorShemes />
+                  </Suspense>
+                </AccordionSection>
+              )}
+            </Accordion>
+          </Tab>
+        )}
 
-        {disabledFeatures.indexOf("advanced-editor") === -1 && (
+        {disabledFeatures.indexOf("advanced-editor") === -1 && !isMap && (
           <Tab label="Advanced">
             <Suspense fallback={<div>Loading...</div>}>
               <AdvancedEditor />

--- a/src/applications/widget-editor/src/components/editor-options/index.js
+++ b/src/applications/widget-editor/src/components/editor-options/index.js
@@ -1,6 +1,7 @@
 import { connectState } from "@widget-editor/shared/lib/helpers/redux";
 
 import { patchConfiguration } from "@widget-editor/shared/lib/modules/configuration/actions";
+import { isMap } from "@widget-editor/shared/lib/modules/configuration/selectors";
 import EditorOptionsComponent from "./component";
 
 export default connectState(
@@ -17,7 +18,7 @@ export default connectState(
     limit: state.configuration.limit,
     donutRadius: state.configuration.donutRadius,
     sliceCount: state.configuration.sliceCount,
-    isMap: state.configuration.chartType === "map",
+    isMap: isMap(state),
     data: state.editor.widgetData,
     orderBy: state.configuration.orderBy,
     compact: state.theme.compact,

--- a/src/applications/widget-editor/src/components/editor/component.js
+++ b/src/applications/widget-editor/src/components/editor/component.js
@@ -110,13 +110,16 @@ class Editor extends React.Component {
   resolveEditorFunctionality() {
     const {
       setEditor,
-      disable = [],
+      disable,
       enableSave = true,
     } = this.props;
 
     setEditor({
-      disabledFeatures: disable,
       enableSave,
+      ...(disable !== undefined && disable !== null
+        ? {disabledFeatures: disable }
+        : {}
+      ),
     });
   }
 

--- a/src/applications/widget-editor/src/components/tabs/style.js
+++ b/src/applications/widget-editor/src/components/tabs/style.js
@@ -37,20 +37,25 @@ export const StyledTabsContent = styled.div`
 
 export const StyledList = styled.ul`
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   padding: 20px 30px 20px 0;
   list-style: none;
 `;
 
 export const StyledListLabel = styled.li`
   color: red;
-  padding-right: 5px;
-  padding-left: 5px;
+  margin: 0 5px 0 0;
 
-  &:first-child {
-    padding-left: 0;
-  }
   &:last-child {
-    padding-right: 0;
+    margin-right: 0;
+  }
+
+  button[aria-pressed = "true"] {
+    border-width: 2px !important;
+  }
+
+  button[aria-pressed = "false"] {
+    // Prevent the change from a 1px width to a 2px width to cause a jump
+    margin: 0 1px;
   }
 `;

--- a/src/packages/shared/package.json
+++ b/src/packages/shared/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "babel-plugin-styled-components": "^1.10.6",
-    "react-resize-detector": "^4.2.1",
     "react-select": "^3.0.8",
     "react-slick": "^0.25.2",
     "react-slider": "^1.0.2",

--- a/src/packages/shared/src/components/button/component.js
+++ b/src/packages/shared/src/components/button/component.js
@@ -16,6 +16,11 @@ const StyledButton = styled.button`
     opacity: 0.5;
   }
 
+  &[aria-pressed = "true"]:not([disabled]) {
+    border: 1px solid ${props => props.color};
+    color: ${props => props.color};
+  }
+
   ${(props) =>
     props.size &&
     props.size === "small" &&
@@ -44,8 +49,7 @@ const StyledButton = styled.button`
     props.btnType &&
     props.btnType === "default" &&
     css`
-      &:hover:not([disabled]),
-      &.active:not([disabled]) {
+      &:hover:not([disabled]) {
         ${(props) =>
           props.color &&
           css`
@@ -54,16 +58,9 @@ const StyledButton = styled.button`
           `}
       }
     `}
-
-  ${(props) =>
-    props.active &&
-    css`
-      border: 1px solid ${props.color};
-      color: ${props.color};
-    `}
 `;
 
-const Button = ({ type, btnType = "default", theme, children, ...props }) => {
+const Button = ({ type, btnType = "default", theme, children, active, ...props }) => {
   return (
     <StyledButton
       {...props}
@@ -71,6 +68,10 @@ const Button = ({ type, btnType = "default", theme, children, ...props }) => {
       type="button"
       role="button"
       btnType={btnType}
+      {...(typeof active === 'boolean'
+        ? { 'aria-pressed': active }
+        : {}
+      )}
     >
       {children}
     </StyledButton>

--- a/src/packages/shared/src/components/icons/AccordionArrow/index.js
+++ b/src/packages/shared/src/components/icons/AccordionArrow/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+const AccordionArrow = props => (
+  <svg width="15" height="15" viewBox="0 0 15 15" {...props}>
+    <title>Down arrow</title>
+    <path strokeWidth="2" d="M3 5l4.5 5L12 5" fill="none" />
+  </svg>
+);
+
+export default AccordionArrow;

--- a/src/packages/shared/src/index.js
+++ b/src/packages/shared/src/index.js
@@ -3,6 +3,7 @@ export { default as Select } from "components/select";
 export { default as CategoryIcon } from "components/icons/CategoryIcon";
 export { default as CloseIcon } from "components/icons/CloseIcon";
 export { default as ArrowIcon } from "components/icons/ArrowIcon";
+export { default as AccordionArrow } from "components/icons/AccordionArrow";
 export { default as redux } from "helpers/redux";
 export { default as getEditorMeta } from "./editor-meta";
 export { default as tags } from "./template-tags";

--- a/src/packages/shared/src/modules/configuration/selectors.js
+++ b/src/packages/shared/src/modules/configuration/selectors.js
@@ -4,6 +4,7 @@ import { selectDisabledFeatures } from "../editor/selectors";
 
 const selectAvailableCharts = state => state.configuration.availableCharts;
 const selectRasterOnly = state => state.configuration.rasterOnly;
+const selectChartType = state => state.configuration.chartType;
 
 export const selectChartOptions = createSelector(
   [selectAvailableCharts, selectRasterOnly, selectDisabledFeatures],
@@ -20,4 +21,9 @@ export const selectChartOptions = createSelector(
 
     return res;
   },
+);
+
+export const isMap = createSelector(
+  [selectChartType],
+  chartType => chartType === 'map',
 );

--- a/src/packages/shared/src/modules/editor/initial-state.js
+++ b/src/packages/shared/src/modules/editor/initial-state.js
@@ -1,6 +1,6 @@
 export default {
   restoring: false,
-  disabledFeatures: [],
+  disabledFeatures: ['typography'],
   dataSync: false,
   map: null,
   initialized: false,

--- a/src/playground/widget-editor/src/components/editor/component.js
+++ b/src/playground/widget-editor/src/components/editor/component.js
@@ -89,7 +89,6 @@ class Editor extends React.Component {
         <WidgetEditor
           schemes={SCHEMES}
           compact={compactMode}
-          disable={[]}
           datasetId={dataset}
           widgetId={widget}
           onSave={this.handleOnSave}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9269,11 +9269,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
-
 lodash._arrayeach@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz#bab156b2a90d3f1bbd5c653403349e5e5933ef9e"
@@ -12064,11 +12059,6 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-raf-schd@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
-  integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
-
 raf@^3.4.0, raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -12383,17 +12373,6 @@ react-redux@^7.1.3:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
-
-react-resize-detector@^4.2.1:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-4.2.3.tgz#7df258668a30bdfd88e655bbdb27db7fd7b23127"
-  integrity sha512-4AeS6lxdz2KOgDZaOVt1duoDHrbYwSrUX32KeM9j6t9ISyRphoJbTRCMS1aPFxZHFqcCGLT1gMl3lEcSWZNW0A==
-  dependencies:
-    lodash "^4.17.15"
-    lodash-es "^4.17.15"
-    prop-types "^15.7.2"
-    raf-schd "^4.0.2"
-    resize-observer-polyfill "^1.5.1"
 
 react-scripts@3.2.0:
   version "3.2.0"


### PR DESCRIPTION
This PR improves the UI of the settings by:
- Moving the map settings to their own tab
- Opening by default the accordions that are alone in each tab
- Aligning the tabs to the left, reducing the margins between them and increasing the border width of the selected one
- Adding the correct icon to the accordions
- Disabling the “Typography” accordion by default (since it is not implemented)

## Testing instructions

Just play with the tabs and accordions in the playground.

## Pivotal Tracker

Not tracked.
