### PR TITLE
Fix a bug preventing using the editor in other apps

### DIFF
--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -1,7 +1,7 @@
 import { takeLatest, put, select, all, fork, call, take, cancel } from "redux-saga/effects";
 import { constants } from "@widget-editor/core";
 
-import { LABELS, BASEMAPS } from "@widget-editor/map/src/constants";
+import { LABELS, BASEMAPS } from "@widget-editor/map/lib/constants";
 import { setConfiguration, resetConfiguration } from "@widget-editor/shared/lib/modules/configuration/actions";
 import { setEditor, resetEditor } from "@widget-editor/shared/lib/modules/editor/actions";
 


### PR DESCRIPTION
**⚠️ This is a hotfix.** Once approved, it must be merged in `master` and `develop`.

---

This PR fixes a wrong import that prevents other apps from successfully importing the widget-editor.

## Testing instructions

Use `yarn link` to test the widget-editor in the `develop` branch of [RW](https://github.com/resource-watch/resource-watch/). Alternatively, if `yarn link` doesn't pick the change, navigate to `resource-watch/node_modules/@widget-editor/widget-editor/lib/sagas/editor/index.js` and replace `var _constants = require("@widget-editor/map/src/constants");` by `var _constants = require("@widget-editor/map/lib/constants");`.

Once you've done so, run RW: `yarn dev`. Going to `localhost:5000`, you should be able to see the homepage.

## Pivotal Tracker

Not tracked. Reported by Pablo on Slack.
