### PR TITLE
Fix crashes when switching to a map visualisation or when restoring a map widget

### DIFF
--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -56,9 +56,11 @@ function* preloadData() {
           }
         }
         : {
-          basemap: "dark",
-          labels: "none",
-          boundaries: false,
+            basemap: {
+              basemap: "dark",
+              labels: "none",
+              boundaries: false,
+            }
         }),
       ...(widgetConfig.hasOwnProperty("zoom")
         ? { zoom: widgetConfig.zoom }

--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -9,6 +9,7 @@ import {
 
 // SELECTORS
 import { selectScheme } from "@widget-editor/shared/lib/modules/theme/selectors";
+import { isMap } from "@widget-editor/shared/lib/modules/configuration/selectors";
 
 // ACTIONS
 import { setEditor, dataInitialized } from "@widget-editor/shared/lib/modules/editor/actions";
@@ -74,7 +75,7 @@ function* initializeVega(props) {
    * DataService has figured out how a widget will be configured
    * VegaService utilizes store properties and generates a vega config for us
    */
-  if (!advanced) {
+  if (!advanced && !isMap(store)) {
     const vega = new VegaService(
       {
         ...widgetConfig,

--- a/src/packages/shared/src/modules/configuration/reducers.js
+++ b/src/packages/shared/src/modules/configuration/reducers.js
@@ -8,8 +8,26 @@ export default {
     ...state,
     ...payload
   }),
-  [actions.patchConfiguration]: (state, { payload }) => ({
-    ...state,
-    ...payload
-  })
+  [actions.patchConfiguration]: (state, { payload }) => {
+    const otherParams = {};
+
+    // If the user is setting the visualisation to be a map, we set some of its default parameters
+    if (payload?.visualizationType === 'map') {
+      otherParams.map = {
+        ...state.map,
+        basemap: {
+          ...(state.map.basemap ?? {}),
+          basemap: state.map.basemap?.basemap ?? 'dark',
+          labels: state.map.basemap?.labels ?? 'none',
+          boundaries: state.map.basemap?.boundaries ?? false,
+        },
+      };
+    }
+
+    return {
+      ...state,
+      ...payload,
+      ...otherParams,
+    };
+  },
 };


### PR DESCRIPTION
This PR fixes two bugs that crashed the editor when switching to a map visualisation or when restoring a map widget.

## Testing instructions

1. Instantiate the editor with this dataset: `7f08cd35-1171-4cbd-bd8b-89999ddad2bb`
2. Select the map visualisation

The editor must not crash.

3. Instantiate the editor with this widget: `d494608e-103c-4c86-9545-4e72d977daaa` (dataset: `c0c71e67-0088-4d69-b375-85297f79ee75`)

The editor must not crash.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/174272403).