### PR TITLE
Fix errors thrown by the accordion's icon

### DIFF
--- a/src/applications/widget-editor/src/components/accordion/style.js
+++ b/src/applications/widget-editor/src/components/accordion/style.js
@@ -1,3 +1,4 @@
+import React from "react";
 import styled from "styled-components";
 
 import { AccordionArrow } from "@widget-editor/shared"
@@ -33,7 +34,7 @@ export const StyledAccordionButton = styled.button`
   outline: none;
 `;
 
-export const StyledIcon = styled(AccordionArrow)`
+export const StyledIcon = styled(({ themeColor, isOpen, ...rest }) => <AccordionArrow {...rest} />)`
   position: absolute;
   left: 0;
   top: 5px;


### PR DESCRIPTION
This PR removes errors thrown in the console by the accordion's icon. The bug was introduced in #92.

## Testing instructions

Open the playground and make sure no errors are thrown in the console.

## Pivotal Tracker

Not tracked.
