### PR TITLE
Update the output payload of the editor to fix issues with the metadata

### DIFF
--- a/src/adapters/rw-adapter/src/types.ts
+++ b/src/adapters/rw-adapter/src/types.ts
@@ -1,25 +1,3 @@
-type GenericSerializedFilter<T> = {
-  name: string;
-  type: string;
-  value: T | T[];
-  operation?: string;
-  notNull: boolean;
-};
-
-type NumberSerializedFilter = GenericSerializedFilter<number> & {
-  type: 'number';
-}
-
-type DateSerializedFilter = GenericSerializedFilter<string> & {
-  type: 'date';
-};
-
-type StringSerializedFilter = GenericSerializedFilter<string> & {
-  type: 'string';
-};
-
-export type SerializedFilter = NumberSerializedFilter | DateSerializedFilter | StringSerializedFilter;
-
 export type SerializedScheme = {
   name?: string;
   [key: string]: any;

--- a/src/applications/widget-editor/src/components/editor/component.js
+++ b/src/applications/widget-editor/src/components/editor/component.js
@@ -4,7 +4,7 @@ import debounce from "lodash/debounce";
 import Renderer from "@widget-editor/renderer";
 import EditorOptions from "components/editor-options";
 import Footer from "components/footer";
-import { DataService } from "@widget-editor/core";
+import { DataService, getOutputPayload } from "@widget-editor/core";
 import { constants } from "@widget-editor/core";
 import { StyledContainer, StyleEditorContainer } from "./style";
 
@@ -152,12 +152,10 @@ class Editor extends React.Component {
   }, 1000);
 
   onSave() {
-    const { onSave, dispatch, editorState, adapter, application } = this.props;
-    if (
-      typeof onSave === "function" &&
-      typeof adapter.handleSave === "function"
-    ) {
-      adapter.handleSave(onSave, this.dataService, application, editorState);
+    const { onSave, dispatch, editorState, adapter } = this.props;
+    if (typeof onSave === "function") {
+      const outputPayload = getOutputPayload(editorState, adapter);
+      onSave(outputPayload);
     }
     dispatch({ type: constants.sagaEvents.EDITOR_SAVE });
   }

--- a/src/applications/widget-editor/src/exposed-hooks/index.js
+++ b/src/applications/widget-editor/src/exposed-hooks/index.js
@@ -1,4 +1,4 @@
-import { constants } from "@widget-editor/core";
+import { constants, getOutputPayload } from "@widget-editor/core";
 
 let localCache = {};
 let REDUX_CACHE_DISPATCH = null;
@@ -17,29 +17,19 @@ export const localGetEditorState = (payload) => {
 };
 
 export const localOnChangeState = (editorState) => {
-  if (
-    localCache.adapter &&
-    typeof localCache.adapter.handleSave === "function" &&
-    !!editorState.editor.dataset
-  ) {
-    localCache.adapter.handleSave(
-      (result) => {
-        localCache = {
-          ...localCache,
-          adapterPayload: result,
-          editorState,
-        };
-      },
-      localCache.dataService,
-      localCache.adapter.applications.join(","),
-      editorState
-    );
+  if (localCache.adapter && !!editorState.editor.dataset) {
+    const outputPayload = getOutputPayload(editorState, localCache.adapter);
+    localCache = {
+      ...localCache,
+      outputPayload,
+      editorState,
+    };
   }
 };
 
 export const publicOnSave = () => {
   return {
-    payload: localCache.adapterPayload,
+    payload: localCache.outputPayload,
     editorState: localCache.editorState,
   };
 };

--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -30,7 +30,7 @@ function* preloadData() {
   if (editor.widget) {
     const {
       widget: {
-        attributes: { name, caption, description, widgetConfig },
+        attributes: { name, metadata, description, widgetConfig },
       },
     } = editor;
 
@@ -66,6 +66,9 @@ function* preloadData() {
         ? { zoom: widgetConfig.zoom }
         : {}),
     };
+
+    const relevantMetadata = metadata?.[0];
+    const caption = relevantMetadata?.attributes.info?.caption ?? '';
 
     const datasetType = editor?.dataset?.attributes?.type;
     const rasterOnly = !!(datasetType && datasetType.match(/raster/));

--- a/src/packages/core/src/filters/index.ts
+++ b/src/packages/core/src/filters/index.ts
@@ -1,0 +1,50 @@
+import * as Generic from '@widget-editor/types/build/generic';
+import * as Filters from '@widget-editor/types/build/filters';
+import * as Dataset from '@widget-editor/types/build/dataset';
+import FiltersService from '../services/filters';
+
+/**
+ * Serialize the editor's filters for the widgetConfig
+ * @param filters Filters
+ */
+export const getSerializedFilters = (filters: Filters.Filter[]): Filters.SerializedFilter[] => {
+  const getSerializedValue = ({ type, value }) => {
+    if (type === 'date') {
+      if (Array.isArray(value)) {
+        return value.map(date => date.toISOString());
+      }
+
+      return value.toISOString();
+    }
+
+    return value;
+  }
+
+  return filters
+    .filter(filter => filter.value !== undefined && filter.value !== null)
+    .map(filter => ({
+      name: filter.column,
+      type: filter.type,
+      operation: filter.operation,
+      value: getSerializedValue(filter),
+      notNull: filter.notNull,
+    }));
+};
+
+/**
+ * Deserialize the filters for for the widget-editor's application
+ * @param filters Serialized filters
+ * @param fields Dataset's fields
+ * @param dataset Dataset object
+ */
+export const getDeserializedFilters = async (
+  filters: Filters.SerializedFilter[],
+  fields: Generic.Array,
+  dataset: Dataset.Payload
+): Promise<Filters.Filter[]> => {
+  if (!filters || !Array.isArray(filters) || filters.length === 0) {
+    return [];
+  }
+
+  return await FiltersService.getDeserializedFilters(filters, fields, dataset);
+};

--- a/src/packages/core/src/index.ts
+++ b/src/packages/core/src/index.ts
@@ -19,3 +19,5 @@ export { StateProxy };
 export { Filters as FiltersService };
 export { Datasets as DatasetService };
 export { Widget as WidgetService };
+export * from './filters';
+export { default as getOutputPayload } from './output-payload';

--- a/src/packages/core/src/output-payload/index.ts
+++ b/src/packages/core/src/output-payload/index.ts
@@ -1,0 +1,125 @@
+import { Generic, Adapter, Widget } from '@widget-editor/types';
+import getEditorMeta from '@widget-editor/shared/lib/editor-meta';
+import {
+  selectTitle,
+  selectDescription,
+  selectVisualizationType,
+  selectLimit,
+  selectValue,
+  selectCategory,
+  selectColor,
+  selectSize,
+  selectOrderBy,
+  selectAggregateFunction,
+  selectChartType,
+  selectAreaIntersection,
+  selectBand,
+  selectDonutRadius,
+  selectSliceCount,
+  selectLayer,
+  selectCaption,
+} from '@widget-editor/shared/lib/modules/configuration/selectors';
+import { selectSerializedWidgetConfig } from '@widget-editor/shared/lib/modules/widget-config/selectors';
+import {
+  selectAdvanced,
+  selectZoom,
+  selectLat,
+  selectLng,
+  selectBounds,
+  selectBbox,
+  selectBasemap,
+} from '@widget-editor/shared/lib/modules/editor/selectors';
+import { selectFiltersList } from '@widget-editor/shared/lib/modules/filters/selectors';
+import { getSerializedFilters } from '../filters';
+
+/**
+ * Return the serialized widgetConfig object
+ * @param store Redux store
+ * @param adapter Instance of the adapter
+ */
+const getSerializedWidgetConfig = (
+  store: Generic.ReduxStore,
+  adapter: Adapter.Service,
+): Widget.WidgetConfig => {
+  // reason
+  const advanced = selectAdvanced(store);
+
+  const serializedWidgetConfig: { [key: string]: any } = {};
+
+  if (selectVisualizationType(store) !== 'map') {
+    const widgetConfig = selectSerializedWidgetConfig(store);
+    Object.keys(widgetConfig).forEach((key) => {
+      serializedWidgetConfig[key] = widgetConfig[key];
+    });
+
+    // $schema must be removed because the RW API doesn't support keys that start with the $ symbol
+    // This should probably live in the adapter, but it's safe to remove for all of the adapters
+    if (serializedWidgetConfig.$schema) {
+      delete serializedWidgetConfig.$schema;
+    }
+
+    if (!advanced) {
+      serializedWidgetConfig.paramsConfig = {
+        visualizationType: selectVisualizationType(store),
+        limit: selectLimit(store),
+        value: selectValue(store),
+        category: selectCategory(store),
+        color: selectColor(store),
+        size: selectSize(store),
+        orderBy: selectOrderBy(store),
+        aggregateFunction: selectAggregateFunction(store),
+        chartType: selectChartType(store),
+        filters: getSerializedFilters(selectFiltersList(store)),
+        areaIntersection: selectAreaIntersection(store),
+        band: selectBand(store),
+        donutRadius: selectDonutRadius(store),
+        sliceCount: selectSliceCount(store),
+      };
+    }
+  } else {
+    serializedWidgetConfig.type = 'map';
+    serializedWidgetConfig.layer_id = selectLayer(store);
+    serializedWidgetConfig.zoom = selectZoom(store);
+    serializedWidgetConfig.lat = selectLat(store);
+    serializedWidgetConfig.lng = selectLng(store);
+    serializedWidgetConfig.bounds = selectBounds(store);
+    serializedWidgetConfig.bbox = selectBbox(store);
+
+    if (selectBasemap(store)) {
+      serializedWidgetConfig.basemapLayers = selectBasemap(store);
+    }
+
+    serializedWidgetConfig.paramsConfig = {
+      visualizationType: selectVisualizationType(store),
+      layer: selectLayer(store),
+    };
+  }
+
+  serializedWidgetConfig.we_meta = getEditorMeta(adapter.getName(), advanced);
+
+  return serializedWidgetConfig;
+};
+
+
+/**
+ * Return the output of the widget-editor
+ * @param store Redux store
+ * @param adapter Instance of the adapter
+ */
+const getOutputPayload = (
+  store: Generic.ReduxStore,
+  adapter: Adapter.Service,
+): Generic.OutputPayload => {
+  return {
+    name: selectTitle(store),
+    description: selectDescription(store),
+    widgetConfig: getSerializedWidgetConfig(store, adapter),
+    metadata: {
+      // NOTE: the output doesn't contain *all* of the widget's metadata, but only what the editor
+      // cares about
+      caption: selectCaption(store),
+    }
+  };
+};
+
+export default getOutputPayload;

--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -8,6 +8,7 @@ import VegaService from "./vega";
 import { setAdapter } from "../helpers/adapter";
 
 import { sagaEvents, reduxActions, ALLOWED_FIELD_TYPES } from "../constants";
+import { getDeserializedFilters } from '../filters';
 
 export default class DataService {
   adapter: Adapter.Service;
@@ -101,7 +102,7 @@ export default class DataService {
         color = paramsConfig.color;
       }
 
-      const deserializedFilters = await this.adapter.getDeserializedFilters(
+      const deserializedFilters = await getDeserializedFilters(
         filters,
         this.allowedFields,
         this.dataset

--- a/src/packages/map/src/index.js
+++ b/src/packages/map/src/index.js
@@ -8,6 +8,7 @@ import styled from "styled-components";
 import { Icons } from 'vizzuality-components';
 
 import { editorSyncMap } from "@widget-editor/shared/lib/modules/editor/actions";
+import { patchConfiguration } from "@widget-editor/shared/lib/modules/configuration/actions";
 
 import LayerManager from "helpers/layer-manager";
 
@@ -310,12 +311,13 @@ class Map extends React.Component {
   }
 
   onMapChange() {
-    const { editorSyncMap } = this.props;
+    const { editorSyncMap, patchConfiguration } = this.props;
     if (editorSyncMap) {
       const mapParams = this.getMapParams();
       const { zoom } = mapParams;
       const { lat, lng } = mapParams.latLng;
       const [bbox1, bbox2] = mapParams.bounds;
+
       editorSyncMap({
         lat,
         lng,
@@ -324,6 +326,7 @@ class Map extends React.Component {
         bounds: mapParams.bounds,
         bbox: [...bbox1, ...bbox2]
       });
+      patchConfiguration();
     }
   }
 
@@ -403,8 +406,11 @@ class Map extends React.Component {
 }
 
 export default redux.connectState(
-  (state) => ({
+  state => ({
     configuration: state.configuration,
   }),
-  { editorSyncMap }
+  {
+    editorSyncMap,
+    patchConfiguration,
+  }
 )(Map);

--- a/src/packages/shared/src/modules/configuration/initial-state.js
+++ b/src/packages/shared/src/modules/configuration/initial-state.js
@@ -1,5 +1,6 @@
 export default {
   title: "",
+  description: "",
   caption: "",
   format: "",
   visualizationType: "chart",

--- a/src/packages/shared/src/modules/configuration/selectors.js
+++ b/src/packages/shared/src/modules/configuration/selectors.js
@@ -4,7 +4,24 @@ import { selectDisabledFeatures } from "../editor/selectors";
 
 const selectAvailableCharts = state => state.configuration.availableCharts;
 const selectRasterOnly = state => state.configuration.rasterOnly;
-const selectChartType = state => state.configuration.chartType;
+export const selectTitle = state => state.configuration.title;
+export const selectDescription = state => state.configuration.description;
+export const selectVisualizationType = state => state.configuration.visualizationType;
+export const selectLimit = state => state.configuration.limit;
+export const selectValue = state => state.configuration.value;
+export const selectCategory = state => state.configuration.category;
+export const selectColor = state => state.configuration.color;
+export const selectSize = state => state.configuration.size;
+export const selectOrderBy = state => state.configuration.orderBy;
+export const selectAggregateFunction = state => state.configuration.aggregateFunction;
+export const selectChartType = state => state.configuration.chartType;
+export const selectFilters = state => state.configuration.filters;
+export const selectAreaIntersection = state => state.configuration.areaIntersection;
+export const selectBand = state => state.configuration.band;
+export const selectDonutRadius = state => state.configuration.donutRadius;
+export const selectSliceCount = state => state.configuration.sliceCount;
+export const selectLayer = state => state.configuration.layer;
+export const selectCaption = state => state.configuration.caption;
 
 export const selectChartOptions = createSelector(
   [selectAvailableCharts, selectRasterOnly, selectDisabledFeatures],

--- a/src/packages/shared/src/modules/editor/selectors.js
+++ b/src/packages/shared/src/modules/editor/selectors.js
@@ -5,6 +5,18 @@ import { getLocalCache } from '@widget-editor/widget-editor/lib/exposed-hooks';
 export const selectDisabledFeatures = state => state.editor.disabledFeatures;
 export const selectAdvanced = state => state.editor.advanced;
 export const selectWidget = state => state.editor.widget;
+export const selectZoom = state => state.editor.map?.zoom ?? null;
+export const selectLat = state => state.editor.map?.lat ?? null;
+export const selectLng = state => state.editor.map?.lng ?? null;
+export const selectBounds = state => state.editor.map?.bounds ?? null;
+export const selectBbox = state => state.editor.map?.bbox ?? null;
+export const selectBasemap = state => state.editor.map?.basemap
+  ? {
+    basemap: state.editor.map.basemap.basemap,
+    labels: state.editor.map.basemap.labels || null,
+    boundaries: state.editor.map.basemap.boundaries || false,
+  }
+  : null;
 
 export const selectWidgetConfig = createSelector(
   [selectWidget],

--- a/src/packages/shared/src/modules/filters/selectors.js
+++ b/src/packages/shared/src/modules/filters/selectors.js
@@ -1,0 +1,1 @@
+export const selectFiltersList = state => state.filters.list;

--- a/src/packages/shared/src/modules/widget-config/selectors.js
+++ b/src/packages/shared/src/modules/widget-config/selectors.js
@@ -2,6 +2,7 @@ import { createSelector } from "reselect";
 
 import { getLocalCache } from "@widget-editor/widget-editor/lib/exposed-hooks";
 import { selectIsWidgetAdvanced } from "@widget-editor/shared/lib/modules/editor/selectors";
+import { selectScheme } from "@widget-editor/shared/lib/modules/theme/selectors";
 
 const SINGLE_COLOR_OPTION = {
   alias: "Single color",
@@ -125,8 +126,8 @@ export const getSelectedColor = createSelector(
 );
 
 export const selectSerializedWidgetConfig = createSelector(
-  [selectWidgetConfig, selectIsWidgetAdvanced],
-  (widgetConfig, isAdvancedWidget) => {
+  [selectWidgetConfig, selectIsWidgetAdvanced, selectScheme],
+  (widgetConfig, isAdvancedWidget, scheme) => {
     const { adapter } = getLocalCache();
     const config = { ...(widgetConfig ?? {}) };
 
@@ -152,6 +153,9 @@ export const selectSerializedWidgetConfig = createSelector(
         return data;
       });
     }
+
+    // We serialise the selected scheme
+    config.config = adapter.getSerializedScheme(scheme);
 
     return config;
   }

--- a/src/packages/types/src/adapter.ts
+++ b/src/packages/types/src/adapter.ts
@@ -17,6 +17,7 @@ export interface Service {
   datasetId: datasetId;
   requestQue: any;
   isAborting: boolean;
+  getName(): string;
   // Used when saving data
   // This will be grabbed and put into onSave on any request
   prepareRequest(url: string): Promise<any>;
@@ -32,11 +33,6 @@ export interface Service {
   getDataUrl(): string;
   getLayers(): Promise<[object]>;
   setDatasetId(datasetId: datasetId): void;
-  getDeserializedFilters(
-    filters: any[],
-    fields: Generic.Array[],
-    dataset: Dataset.Payload
-  ): Promise<Filters.Filter[]>;
   getSerializedScheme(config: Widget.Scheme): any;
   getDeserializedScheme(config: any): Widget.Scheme;
 }

--- a/src/packages/types/src/filters.ts
+++ b/src/packages/types/src/filters.ts
@@ -34,4 +34,25 @@ export type StringFilter = GenericFilter<string> & {
 
 export type Filter = NumberFilter | DateFilter | StringFilter;
 
-export type SerializedFilter = any;
+type GenericSerializedFilter<T> = {
+  name: string;
+  type: string;
+  value: T | T[];
+  operation?: string;
+  notNull: boolean;
+};
+
+type NumberSerializedFilter = GenericSerializedFilter<number> & {
+  type: 'number';
+}
+
+type DateSerializedFilter = GenericSerializedFilter<string> & {
+  type: 'date';
+};
+
+type StringSerializedFilter = GenericSerializedFilter<string> & {
+  type: 'string';
+};
+
+export type SerializedFilter = NumberSerializedFilter | DateSerializedFilter | StringSerializedFilter;
+

--- a/src/packages/types/src/generic.ts
+++ b/src/packages/types/src/generic.ts
@@ -1,3 +1,14 @@
+import * as Widget from './widget';
+
 export type ObjectPayload = object[];
 export type Dispatcher = (object) => void;
 export type Array = any[];
+export type ReduxStore = any;
+export type OutputPayload = {
+  name: string,
+  description: string,
+  widgetConfig: Widget.WidgetConfig,
+  metadata: {
+    caption: string,
+  },
+};

--- a/src/packages/types/src/widget.ts
+++ b/src/packages/types/src/widget.ts
@@ -11,15 +11,13 @@ export interface Payload {
     slug: string;
     description: string;
     application: [string];
-    widgetConfig: {
-      value: any;
-      category: any;
-      paramsConfig: any;
-    };
+    widgetConfig: WidgetConfig;
     defaultEditableWidget: boolean;
     env: string;
   };
 }
+
+export type WidgetConfig = any;
 
 export type Scheme = {
   name: string;


### PR DESCRIPTION
This PR updates the output payload of the editor to fix issues with the metadata.

The new output has [this signature](https://github.com/Vizzuality/widget-editor/blob/8eaf6d66e357183374155d06d49ae7270c251de8/src/packages/types/src/generic.ts#L7-L14):
```ts
type OutputPayload = {
  name: string,
  description: string,
  widgetConfig: Widget.WidgetConfig,
  metadata: {
    caption: string,
  },
};
```

It's important to note that the `metadata` object will _not_ contain all of the widget's metadata, but only the metadata the editor handles. Hence only one property is defined at this moment.

In addition, this PR fixes an issue where the widget's caption would not be shown in the editor.

## Testing instructions

In general, make sure we have no regression, in particular with:
- Filters
- Settings such as the order, limit
- The title, description and caption
- The advanced mode
- The map

In addition, and for the same cases as above, make sure the payload is correct and up-to-date.

Finally, to test the bug fix (for the caption not being shown in the editor), you can test with this widget: `db885f7c-d183-471b-8d58-2c250a10719d` (dataset: `05b7c688-09ba-4f33-90ea-185a1039df43`).

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/172821231).
