### PR TITLE
Fix an issue preventing the user from creating a map

### DIFF
--- a/src/applications/renderer/src/components/renderer/component.js
+++ b/src/applications/renderer/src/components/renderer/component.js
@@ -93,13 +93,12 @@ const Renderer = ({
 
       {initialized && !restoring && isMap && (
         <Suspense fallback={<div>Loading...</div>}>
-          {editor.widget && editor.layers && (
+          {!!editor.layers && (
             <Map
               mapConfiguration={configuration.map}
-              caption={editor.widget?.attributes?.name}
+              caption={configuration.title}
               layerId={configuration.layer}
               interactionEnabled={!standalone}
-              widget={editor.widget}
               layers={editor.layers}
               changeBbox={changeBbox}
             />

--- a/src/packages/map/src/index.js
+++ b/src/packages/map/src/index.js
@@ -65,13 +65,10 @@ class Map extends React.Component {
     };
 
     this.labels = props.labels || LABELS["none"];
-    this.widget = props.widget;
 
     this.mapConfiguration = props?.mapConfiguration
       ? props.mapConfiguration
       : DEFAULT_MAP_PROPERTIES;
-
-    this.widgetConfig = this.widget.attributes.widgetConfig;
 
     this.layers = props.layers;
     this.layerGroups = this.createLayerGroups(this.layers, props.layerId);


### PR DESCRIPTION
This PR fixes an issue where the map wouldn't be shown when the user would switch to the map visualisation, when the editor is only instantiated with a dataset.

## Testing instructions

1. Instantiate the editor with the dataset: `05b7c688-09ba-4f33-90ea-185a1039df43`
2. Select the map visualisation

The map must be shown, with a default layer selected.

3. Instantiate the editor with this widget: `6f95fcef-0e9f-433a-a107-5b86c5fb7f07` (dataset: `4d3d6f25-6e66-426f-be9b-32777b4755cc`)

The widget must be restored: it's a map with the data mostly in the south of Africa.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/174322836).