### PR TITLE
Fix crashes that happen within the playground

### DIFF
--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -63,6 +63,7 @@ export default class DataService {
     const filters = await this.handleFilters(true);
 
     if (
+      this.widget &&
       this.widget.attributes?.widgetConfig?.paramsConfig &&
       this.widget.attributes?.widgetConfig?.value &&
       this.widget.attributes?.widgetConfig?.category
@@ -71,7 +72,9 @@ export default class DataService {
     } else {
       this.setEditor({
         widgetData: null,
-        advanced: !this.widget?.attributes?.widgetConfig?.paramsConfig
+        advanced: !this.widget?.attributes?.widgetConfig
+          ? false
+          : !this.widget.attributes.widgetConfig.paramsConfig
       });
     }
 

--- a/src/packages/map/src/index.js
+++ b/src/packages/map/src/index.js
@@ -89,7 +89,7 @@ class Map extends React.Component {
   }
 
   createLayerGroups(layers, layerId) {
-    if (!layers || !layers.reduce(Boolean)) {
+    if (!layers?.length) {
       return [];
     }
     return layers.map(({ id, attributes }) => ({


### PR DESCRIPTION
This PR fixes bugs that crashes the editor and that can be replicated using the playground's datasets and widgets:
1. Editor would crash when its passed a new dataset ID (but no widget)
2. Editor would crash when restoring a map widget that uses a non-existing layer ID

Note that some of the playground's widgets produce errors in the console, but this is because the advanced widgets contain some invalid Vega JSON.

## Testing instructions

For the first issue:
1. Open the playground
2. Change the dataset via the UI

The editor must not crash.

For the second issue:
1. Instantiate the editor with this widget: `96e5e426-33a8-40fe-9f7f-f36d9db82a8c` (dataset: `2223f9c9-1acf-4e37-b807-f4b7063b47b1`)

The editor must not crash.

## Pivotal Tracker

Not tracked.
