### PR TITLE
fix/map-sync

### DIFF
--- a/src/applications/widget-editor/src/components/map-info/component.js
+++ b/src/applications/widget-editor/src/components/map-info/component.js
@@ -37,7 +37,7 @@ const generateOptions = (layers) => {
   }));
 };
 
-const MapInfo = ({ editor, configuration, patchConfiguration }) => {
+const MapInfo = ({ editor, configuration, patchConfiguration, editorSyncMap }) => {
   const { layers = null } = editor;
   const options = generateOptions(layers);
   const selectedOption = options.find((o) => o.value === configuration.layer);
@@ -58,38 +58,44 @@ const MapInfo = ({ editor, configuration, patchConfiguration }) => {
   };
 
   const setBasemap = (basemap) => {
+    const patch = {
+      ...configuration.map,
+      basemap: {
+          ...configuration.map.basemap,
+          basemap
+      }
+    }
+    editorSyncMap(patch)
     patchConfiguration({
-      map: {
-        ...configuration.map,
-        basemap: {
-            ...configuration.map.basemap,
-            basemap
-        }
-      },
+      map: patch
     });
   };
 
   const setLabels = (label) => {
+    const patch = {
+      ...configuration.map,
+      basemap: {
+        ...configuration.map.basemap,
+       labels: label
+      }
+    }
+    editorSyncMap(patch)
     patchConfiguration({
-      map: {
-        ...configuration.map,
-        basemap: {
-          ...configuration.map.basemap,
-         labels: label
-        },
-      },
+      map: patch
     });
   }
 
   const setBoundaries = (active) => {
+    const patch = {
+      ...configuration.map,
+      basemap: {
+          ...configuration.map.basemap,
+          boundaries: active
+      }
+    };
+    editorSyncMap(patch)
     patchConfiguration({
-      map: {
-        ...configuration.map,
-        basemap: {
-            ...configuration.map.basemap,
-            boundaries: active
-        }
-      },
+      map: patch
     });
   }
 

--- a/src/applications/widget-editor/src/components/map-info/index.js
+++ b/src/applications/widget-editor/src/components/map-info/index.js
@@ -1,6 +1,7 @@
 import { connectState } from "@widget-editor/shared/lib/helpers/redux";
 
 import { patchConfiguration } from "@widget-editor/shared/lib/modules/configuration/actions";
+import { editorSyncMap } from "@widget-editor/shared/lib/modules/editor/actions";
 
 // Components
 import MapInfoComponent from "./component";
@@ -10,5 +11,5 @@ export default connectState(
     editor: state.editor,
     configuration: state.configuration,
   }),
-  { patchConfiguration }
+  { patchConfiguration, editorSyncMap }
 )(MapInfoComponent);


### PR DESCRIPTION
This pr makes sure that when you update map settings, we sync the `editor.map` node within redux, otherwise boundries labels and basemap wont sync and options wont be returned when saving the editor

## Testing instructions

Make sure that when you update basemap, labels boundries that options are returned in get editor state.

## Pivotal Tracker

none