### PR TITLE
Remove a CSS import that prevent host apps from importing the editor

### DIFF
--- a/src/applications/renderer/src/components/renderer/global-style.js
+++ b/src/applications/renderer/src/components/renderer/global-style.js
@@ -1,9 +1,10 @@
 import { createGlobalStyle } from "styled-components";
-import "vega-tooltip/build/vega-tooltip.min.css";
 
 export default createGlobalStyle`
-  // We increase the specificity to override the default styles
-  div.vg-tooltip.light-theme {
+  .vg-tooltip {
+    visibility: hidden;
+    position: fixed;
+    z-index: 2000;
     padding: 15px;
     background-color: #FFF;
     border-radius: 4px;
@@ -15,12 +16,17 @@ export default createGlobalStyle`
 
     tr {
       td.key {
+        max-width: 150px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         padding-right: 20px;
-        text-align: left;
         color: #808080;
       }
 
       td.value {
+        max-width: 200px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: 700;
       }
 


### PR DESCRIPTION
This PR removes a CSS import added in #98, which prevents host apps from being able to import the widget-editor in their codebase.

## Testing instructions

Open the playground, create a chart widget and make sure the tooltip is shown correctly.

## Pivotal Tracker

Not tracked.