### PR TITLE
Change the default vega renderer

### DIFF
--- a/src/applications/renderer/src/components/chart/component.js
+++ b/src/applications/renderer/src/components/chart/component.js
@@ -125,7 +125,8 @@ class Chart extends React.Component {
 
         this.vega = new vega.View(runtime)
           .initialize(chart)
-          .renderer("canvas")
+          // If the renderer is canvas, the fonts defined in the `config` object will be ignored
+          .renderer("svg")
           .width(this.width)
           .height(this.height)
           .hover()


### PR DESCRIPTION
The `Renderer` component was using internally a canvas Vega renderer instead of the SVG Vega renderer used by default in v1. After some tests, it seems that the fonts defined in the `config` object of the widgets are ignored if the canvas renderer is used. For this reason, this PR switches back to the default SVG renderer.

## Testing instructions

Make sure the widgets still render correctly.

## Pivotal Tracker

Not tracked.
