### PR TITLE
Fix a crash caused by a wrong filter deserialisation

### DIFF
--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -332,12 +332,17 @@ export default class FiltersService implements Filters.Service {
       // Resolve metadata for current field
       const fieldService = new FieldsService(dataset, fields);
 
+      let deserializedValue = value;
+      if (type === 'date') {
+        deserializedValue = Array.isArray(value) ? value.map(v => new Date(v)) : new Date(value);
+      }
+
       res.push({
         id: `we-filter-${column}-${index}`,
         column,
         type,
         operation: operation ?? defaultOperation,
-        value,
+        value: deserializedValue,
         notNull,
         config: await fieldService.getFieldInfo(column),
       });


### PR DESCRIPTION
This PR fixes a bug that would crash the editor due to the wrong deserialisation of the date filters.

## Testing instructions

1. Instantiate the editor with this widget: `5a929bd2-8aeb-491d-8814-05d6f9519534` (dataset: `852f2275-91a8-4500-9f10-89880dc53f22`)

Make sure the console doesn't show errors, that the widget is shown correctly and that a date filter is restored.

## Pivotal Tracker

Not tracked.
