### PR TITLE
Fix issues with the (numerical) filters

### DIFF
--- a/src/applications/widget-editor/src/components/query-limit/component.js
+++ b/src/applications/widget-editor/src/components/query-limit/component.js
@@ -1,7 +1,6 @@
-import React, { Fragment, useState, useMemo, useCallback } from "react";
-import debounce from 'lodash/debounce';
-
+import React, { Fragment, useState, useCallback, useMemo } from "react";
 import styled from "styled-components";
+import debounce from 'lodash/debounce';
 
 import FlexContainer from "styles-common/flex";
 import FlexController from "styles-common/flex-controller";
@@ -29,19 +28,7 @@ const QueryLimit = ({
   value,
   onChange = () => null,
 }) => {
-
-  const [localValue, setLocalValue] = useState({ value: value, key: null });
-
-  const changeValue = (data) => {
-    if (data.value !== 0) {
-      setLocalValue(data);
-      debounceOnChange(data);
-    }
-  }
-
-  const debounceOnChange = debounce(q => {
-    onChange(q.value, q.key);
-  }, 1000);
+  const [localValue, setLocalValue] = useState(value);
 
   const isDouble = Array.isArray(localValue);
   const isFloatingPoint = isFloat(min) || isFloat(max);
@@ -52,7 +39,7 @@ const QueryLimit = ({
     minValue = localValue[0];
     maxValue = localValue[1];
   } else {
-    maxValue = localValue.value ?? max;
+    maxValue = localValue ?? max;
   }
 
   const minMaxProps = {
@@ -82,21 +69,19 @@ const QueryLimit = ({
             <Input
               {...minMaxProps}
               step={isFloatingPoint ? 0.1 : 1}
-              value={localValue.value}
+              value={maxValue}
               type={dateType ? "date" : "number"}
               name="options-limit-max"
-              onChange={(e) =>
-                changeValue({ value: e.target.value, key: "maxValue" })
-              }
+              onChange={e => onChangeValue(isDouble ? [min, +e.target.value] : +e.target.value)}
             />
           </FlexController>
           <FlexController contain={80}>
             <Slider
               {...minMaxProps}
               step={isFloatingPoint ? 0.1 : 1}
-              value={isDouble ? [minValue, maxValue] : maxValue}
-              defaultValue={isDouble ? min : [min, max]}
-              onChange={(value) => changeValue({ value, key: null })}
+              value={sliderValue}
+              defaultValue={isDouble ? [min, max] : max}
+              onChange={onChangeValue}
             />
           </FlexController>
         </FlexContainer>
@@ -110,24 +95,25 @@ const QueryLimit = ({
                 <Slider
                   {...minMaxProps}
                   step={isFloatingPoint ? 0.1 : 1}
-                  value={isDouble ? [minValue, maxValue] : maxValue}
-                  defaultValue={isDouble ? min : [min, max]}
-                  onChange={(value) => changeValue({ value, key: null })}
+                  value={sliderValue}
+                  defaultValue={isDouble ? [min, max] : max}
+                  onChange={onChangeValue}
                 />
               </RangeWrapper>
             </FlexController>
           </FlexContainer>
           <FlexContainer row={true}>
             <FlexController contain={50} constrainElement={40}>
-              <Input
-                {...minMaxProps}
-                value={minValue}
-                type={dateType ? "date" : "number"}
-                name="options-limit-min"
-                onChange={(e) =>
-                  changeValue({ value: e.target.value, key: "minValue" })
-                }
-              />
+              {isDouble && (
+                <Input
+                  {...minMaxProps}
+                  step={isFloatingPoint ? 0.1 : 1}
+                  value={minValue}
+                  type={dateType ? "date" : "number"}
+                  name="options-limit-min"
+                  onChange={e => onChangeValue([+e.target.value, maxValue])}
+                />
+            )}
             </FlexController>
             <FlexController
               contain={50}
@@ -140,8 +126,8 @@ const QueryLimit = ({
                 value={maxValue}
                 type={dateType ? "date" : "number"}
                 name="options-limit-max"
-                onChange={(e) =>
-                  changeValue({ value: e.target.value, key: "maxValue" })
+                onChange={e =>
+                  onChangeValue(isDouble ? [minValue, +e.target.value] : +e.target.value)
                 }
               />
             </FlexController>

--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -112,7 +112,7 @@ function* initializeVega(props) {
  * @triggers <void>
  */
 function* syncEditor() {
-  const { widgetEditor } = yield select();
+  let { widgetEditor } = yield select();
 
   if (stateProxy.ShouldUpdateData(widgetEditor)) {
     yield call(initializeData);
@@ -124,6 +124,9 @@ function* syncEditor() {
    * a valid vega configuration.
    * When in advanced mode we save the advanced input into the widgets config.
    */
+
+  // We re-assign the widgetEditor variable because initializeData may modify it
+  ({ widgetEditor } = yield select());
 
   if (stateProxy.ShouldUpdateVega(widgetEditor)) {
     yield call(initializeVega);


### PR DESCRIPTION
This PR fixes an issue where the UI of the numerical filters wouldn't be displayed correctly, and the user may not be able to change them using the inputs.

In addition, when the aforementioned bug was fixed (1st commit), another bug was found in the sagas' main loop: the check, which determines whether to re-render the chart, wouldn't receive the latest store update, preventing the chart from re-rendering when the filters would update.

## Testing instructions

1. Restore the widget `784636ed-ec8b-4198-adef-d9e9e4719f1b` (dataset: `0c3ed5b9-94b4-4fc5-9208-bf749f0a5052`)

Make sure the filter using the column “Average Concentration (µg/m³)” contains values in both the inputs below the slider:
<p align="center">
<img width="628" alt="UI of the filter, both inputs having a value" src="https://user-images.githubusercontent.com/6073968/95080465-0cc46200-0710-11eb-8608-0b8a19df16d8.png">
</p>

2. Update the value of the first input to 10 (or move the handle of the slider)

Make sure the chart is re-rendered after about 1s.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173263197).
