### PR TITLE
Prevent Vega from mutating the store's data

### DIFF
--- a/src/packages/core/src/charts/bars-grouped-horizontal.ts
+++ b/src/packages/core/src/charts/bars-grouped-horizontal.ts
@@ -201,7 +201,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
     return [
       {
         name: "table",
-        values: widgetData,
+        values: [...widgetData].map(d => ({ ...d })),
         ...(this.isDate() ? {
           format: {
             parse: {

--- a/src/packages/core/src/charts/bars-grouped.ts
+++ b/src/packages/core/src/charts/bars-grouped.ts
@@ -200,7 +200,7 @@ export default class GroupedBars extends ChartsCommon implements Charts.Bars {
     return [
       {
         name: "table",
-        values: widgetData,
+        values: [...widgetData].map(d => ({ ...d })),
         ...(this.isDate() ? {
           format: {
             parse: {

--- a/src/packages/core/src/charts/bars-horizontal.ts
+++ b/src/packages/core/src/charts/bars-horizontal.ts
@@ -143,7 +143,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
     return [
       {
         name: "table",
-        values: widgetData,
+        values: [...widgetData].map(d => ({ ...d })),
         ...(this.isDate() ? {
           format: {
             parse: {

--- a/src/packages/core/src/charts/bars-stacked-horizontal.ts
+++ b/src/packages/core/src/charts/bars-stacked-horizontal.ts
@@ -168,7 +168,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
     const { editor: { widgetData } } = this.store;
     return [
       {
-        values: widgetData,
+        values: [...widgetData].map(d => ({ ...d })),
         name: "table",
         ...(this.isDate() ? {
           format: {

--- a/src/packages/core/src/charts/bars-stacked.ts
+++ b/src/packages/core/src/charts/bars-stacked.ts
@@ -168,7 +168,7 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
     const { editor: { widgetData } } = this.store;
     return [
       {
-        values: widgetData,
+        values: [...widgetData].map(d => ({ ...d })),
         name: "table",
         ...(this.isDate() ? {
           format: {

--- a/src/packages/core/src/charts/bars.ts
+++ b/src/packages/core/src/charts/bars.ts
@@ -155,7 +155,7 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
     return [
       {
         name: "table",
-        values: widgetData,
+        values: [...widgetData].map(d => ({ ...d })),
         ...(this.isDate() ? {
           format: {
             parse: {

--- a/src/packages/core/src/charts/line-multi.ts
+++ b/src/packages/core/src/charts/line-multi.ts
@@ -248,7 +248,7 @@ export default class MultiLine extends ChartsCommon implements Charts.Line {
     return [
       {
         name: "table",
-        values: widgetData,
+        values: [...widgetData].map(d => ({ ...d })),
         ...(this.isDate() ? {
           format: {
             parse: {

--- a/src/packages/core/src/charts/line.ts
+++ b/src/packages/core/src/charts/line.ts
@@ -205,7 +205,7 @@ export default class Line extends ChartsCommon implements Charts.Line {
     const { editor: { widgetData } } = this.store;
     return [
       {
-        values: widgetData,
+        values: [...widgetData].map(d => ({ ...d })),
         name: "table",
         ...(this.isDate() ? {
           format: {

--- a/src/packages/core/src/charts/pie.ts
+++ b/src/packages/core/src/charts/pie.ts
@@ -126,7 +126,7 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
     return [
       {
         name: "table",
-        values: widgetData,
+        values: [...widgetData].map(d => ({ ...d })),
       },
       {
         name: "color",

--- a/src/packages/core/src/charts/scatter.ts
+++ b/src/packages/core/src/charts/scatter.ts
@@ -181,7 +181,7 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
     const { editor: { widgetData } } = this.store;
     return [
       {
-        values: widgetData,
+        values: [...widgetData].map(d => ({ ...d })),
         name: "table",
         ...(this.isDate() ? {
           format: {


### PR DESCRIPTION
This PR fixes an issue where the Vega runtime would mutate the store's data: `editor.widgetData`.

## Testing instructions

1. Open `src/packages/core/src/services/state-proxy.ts` and in the function `update`, add this line: `console.log(this.localState?.editor?.widgetData?.[0], state?.editor?.widgetData?.[0]);`
2. Restore this widget `784636ed-ec8b-4198-adef-d9e9e4719f1b` (dataset: `0c3ed5b9-94b4-4fc5-9208-bf749f0a5052`)

Play with the editor: change filters, change the type of chart, etc. Make sure that all the logs in the console don't show Vega mutations like on this screenshot:
<p align="center">
<img width="501" alt="The logs show that vega injected new attributes and modified others" src="https://user-images.githubusercontent.com/6073968/95081755-eef7fc80-0711-11eb-9b24-ef9f5e52f384.png">
</p>

## Pivotal Tracker

Not tracked.
