### PR TITLE
Fix bug where the table would lack its columns header

### DIFF
--- a/src/applications/widget-editor/src/components/table-view/component.js
+++ b/src/applications/widget-editor/src/components/table-view/component.js
@@ -9,8 +9,8 @@ import {
 } from "./style";
 
 const TableView = ({ widgetData, configuration }) => {
-  const value = configuration?.value?.alias || "";
-  const category = configuration?.category?.alias || "";
+  const value = configuration?.value?.alias || configuration?.value?.name || "";
+  const category = configuration?.category?.alias || configuration?.category?.name || "";
 
   return (
     <StyledTableBox>


### PR DESCRIPTION
This PR fixes an issue where the header of the table view would be empty if the columns don't have aliases.

## Testing instructions

1. Instantiate this widget `b867b473-d4f9-4105-b87c-df76caaaf358` (dataset: `852f2275-91a8-4500-9f10-89880dc53f22`)
2. Click the table tab

Make sure the name of the columns are displayed as a header.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/174272709).
