### PR TITLE
Render the charts with contant Y value as in v1

### DIFF
--- a/src/packages/core/src/charts/line.ts
+++ b/src/packages/core/src/charts/line.ts
@@ -84,6 +84,21 @@ export default class Line extends ChartsCommon implements Charts.Line {
   }
 
   setScales() {
+    const { editor: { widgetData: data } } = this.store;
+
+    // In v1, if the chart would display points that have all the same y value, we would modify the
+    // Y domain so it looks nicer
+    let yDomain: any = { data: "table", field: sqlFields.category };
+    const oneYValue = !!data.length
+      && data.every(d => d[sqlFields.category] === data[0][sqlFields.category]);
+    if (data.length === 1 || oneYValue) {
+      // The step is 20% of the value
+      const step = data[0].y * 0.2;
+
+      // We fix the domain around the value
+      yDomain = [data[0].y - step, data[0].y + step];
+    }
+
     return [
       {
         name: "x",
@@ -101,7 +116,7 @@ export default class Line extends ChartsCommon implements Charts.Line {
         range: "height",
         nice: true,
         zero: true,
-        domain: { data: "table", field: sqlFields.category },
+        domain: yDomain,
       },
     ];
   }

--- a/src/packages/core/src/charts/scatter.ts
+++ b/src/packages/core/src/charts/scatter.ts
@@ -67,9 +67,22 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
   }
 
   setScales() {
-    const { configuration: { color } } = this.store;
+    const { configuration: { color }, editor: { widgetData: data } } = this.store;
     const colorField = color?.identifier;
     const scheme = selectScheme(this.store);
+
+    // In v1, if the chart would display points that have all the same y value, we would modify the
+    // Y domain so it looks nicer
+    let yDomain: any = { "data": "filtered", "field": "y" };
+    const oneYValue = !!data.length
+      && data.every(d => d.y === data[0].y);
+    if (data.length === 1 || oneYValue) {
+      // The step is 20% of the value
+      const step = data[0].y * 0.2;
+
+      // We fix the domain around the value
+      yDomain = [data[0].y - step, data[0].y + step];
+    }
 
     const scale: any = [
       {
@@ -91,7 +104,7 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
         round: true,
         nice: true,
         zero: true,
-        domain: { "data": "filtered", "field": "y" },
+        domain: yDomain,
         range: "height",
       },
     ];


### PR DESCRIPTION
In v1, the line and scatter charts where all the data points have the same Y value would be rendered slightly differently so that the value would not appear either at the top or bottom of the chart.

This PR brings back this logic.

## Testing instructions

1. Open the editor with this dataset `852f2275-91a8-4500-9f10-89880dc53f22`
2. Select “year” on the X axis and “same_number” on the Y one
3. Select the line chart

The values must not be displayed at the top of the chart (the domain will go until 1.2).

4. Select the scatter chart

The values must not be displayed at the top of the chart (the domain will go until 1.2).

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173229941) for the line charts and the [one](https://www.pivotaltracker.com/story/show/173229968) for the scatter charts.
