### PR TITLE
Fix a rendering issue with the labels of the horizontal bar charts

### DIFF
--- a/src/packages/core/src/charts/bars-grouped-horizontal.ts
+++ b/src/packages/core/src/charts/bars-grouped-horizontal.ts
@@ -97,12 +97,10 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
                   : "truncate(datum.value, 12)",
               },
               align: {
-                signal:
-                  "width < 300 || data('table')[0].count > 10 ? 'right' : 'center'",
+                value: "right",
               },
               baseline: {
-                signal:
-                  "width < 300 || data('table')[0].count > 10 ? 'middle' : 'top'",
+                value: "top",
               }
             },
           },

--- a/src/packages/core/src/charts/bars-stacked-horizontal.ts
+++ b/src/packages/core/src/charts/bars-stacked-horizontal.ts
@@ -221,7 +221,6 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
   async getChart() {
     await this.generateSchema();
     this.setGenericSettings();
-    console.log(this.schema);
     return this.schema;
   }
 }

--- a/src/packages/core/src/charts/bars-stacked-horizontal.ts
+++ b/src/packages/core/src/charts/bars-stacked-horizontal.ts
@@ -97,12 +97,10 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
                   : "truncate(datum.value, 12)",
               },
               align: {
-                signal:
-                  "width < 300 || data('table')[0].count > 10 ? 'right' : 'center'",
+                value: "right",
               },
               baseline: {
-                signal:
-                  "width < 300 || data('table')[0].count > 10 ? 'middle' : 'top'",
+                value: "top",
               }
             },
           },
@@ -223,6 +221,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
   async getChart() {
     await this.generateSchema();
     this.setGenericSettings();
+    console.log(this.schema);
     return this.schema;
   }
 }


### PR DESCRIPTION
This PR fixes an issue where the Y axis labels of the horizontal bar charts would be displayed partly below the bars.

## Testing instructions

1. Restore this dataset: `a86d906d-9862-4783-9e30-cdb68cd808b8`
2. Select the horizontal stacked bar chart visualisation
3. Select “Country” on the Y axis
4. Select “Capacity (MW)” on the X axis
5. Select “Fuel” in the color select
6. Aggregate the values by sum
7. Filter out every country but China and the USA

The names of the countries must be perfectly visible or with an ellipsis.

8. Switched to a horizontal grouped bar chart

Check the same.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173901133).
