### PR TITLE
Reduce the debounce's wait time of the inputs

### DIFF
--- a/src/applications/widget-editor/src/components/donut-radius/component.js
+++ b/src/applications/widget-editor/src/components/donut-radius/component.js
@@ -28,7 +28,7 @@ const DonutRadius = ({
 
   const debounceOnChange = debounce(q => {
     onChange(q.value, q.key);
-  }, 1000);
+  }, 300);
 
 
   return (

--- a/src/applications/widget-editor/src/components/donut-radius/component.js
+++ b/src/applications/widget-editor/src/components/donut-radius/component.js
@@ -1,6 +1,5 @@
 // TODO: Rename this filter!
 import React, { useState } from "react";
-import debounce from 'lodash/debounce';
 
 import useDebounce from "hooks/use-debounce";
 
@@ -26,9 +25,9 @@ const DonutRadius = ({
     debounceOnChange(data);
   }
 
-  const debounceOnChange = debounce(q => {
+  const debounceOnChange = useDebounce(q => {
     onChange(q.value, q.key);
-  }, 300);
+  });
 
 
   return (

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -92,11 +92,11 @@ const EditorOptions = ({
 
   const handleSliceCount = debounce((value) => {
     patchConfiguration({ sliceCount: parseInt(value) });
-  }, 500);
+  }, 300);
 
   const handleDonutRadius = debounce((value) => {
     patchConfiguration({ donutRadius: parseInt(value) });
-  }, 500);
+  }, 300);
 
   const handleOrderBy = (value) => {
     patchConfiguration({ orderBy: value });
@@ -108,7 +108,7 @@ const EditorOptions = ({
 
   const handleLimit = debounce((value) => {
     patchConfiguration({ limit: value });
-  }, 500);
+  }, 300);
 
   if (!initialized || restoring) {
     return (

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -1,6 +1,7 @@
-import React, { Suspense, useCallback } from "react";
+import React, { Suspense } from "react";
 import styled, { css } from "styled-components";
-import debounce from 'lodash/debounce';
+
+import useDebounce from "hooks/use-debounce";
 
 import { Accordion, AccordionSection } from "components/accordion";
 import { Tabs, Tab } from "components/tabs";
@@ -90,13 +91,13 @@ const EditorOptions = ({
   isMap,
 }) => {
 
-  const handleSliceCount = debounce((value) => {
+  const handleSliceCount = useDebounce((value) => {
     patchConfiguration({ sliceCount: parseInt(value) });
-  }, 300);
+  });
 
-  const handleDonutRadius = debounce((value) => {
+  const handleDonutRadius = useDebounce((value) => {
     patchConfiguration({ donutRadius: parseInt(value) });
-  }, 300);
+  });
 
   const handleOrderBy = (value) => {
     patchConfiguration({ orderBy: value });
@@ -106,9 +107,9 @@ const EditorOptions = ({
     patchConfiguration({ groupBy: value });
   }
 
-  const handleLimit = debounce((value) => {
+  const handleLimit = useDebounce((value) => {
     patchConfiguration({ limit: value });
-  }, 300);
+  });
 
   if (!initialized || restoring) {
     return (

--- a/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -33,7 +33,7 @@ const FilterValue = ({ filter, onChange, ...rest }) => {
   const isFloatingPoint = filter.type === 'number'
     && (isFloat(filter.config.min) || isFloat(filter.config.max));
 
-  const onChangeDebounced = useCallback(debounce(onChange, 500), [onChange]);
+  const onChangeDebounced = useCallback(debounce(onChange, 300), [onChange]);
 
   const onChangeValue = useCallback(({ target }) => {
     let newValue = target.value;

--- a/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -1,7 +1,8 @@
 import React, { useState, useCallback } from "react";
-import debounce from 'lodash/debounce';
 import styled from "styled-components";
 import PropTypes from 'prop-types';
+
+import useDebounce from "hooks/use-debounce";
 
 import Input from "styles-common/input";
 
@@ -33,7 +34,7 @@ const FilterValue = ({ filter, onChange, ...rest }) => {
   const isFloatingPoint = filter.type === 'number'
     && (isFloat(filter.config.min) || isFloat(filter.config.max));
 
-  const onChangeDebounced = useCallback(debounce(onChange, 300), [onChange]);
+  const onChangeDebounced = useDebounce(onChange);
 
   const onChangeValue = useCallback(({ target }) => {
     let newValue = target.value;

--- a/src/applications/widget-editor/src/components/query-limit/component.js
+++ b/src/applications/widget-editor/src/components/query-limit/component.js
@@ -52,7 +52,7 @@ const QueryLimit = ({
     [isDouble, minValue, maxValue]
   );
 
-  const onChangeDebounced = useCallback(debounce(onChange, 1000), [onChange]);
+  const onChangeDebounced = useCallback(debounce(onChange, 300), [onChange]);
 
   const onChangeValue = useCallback((value) => {
     setLocalValue(value);

--- a/src/applications/widget-editor/src/components/query-limit/component.js
+++ b/src/applications/widget-editor/src/components/query-limit/component.js
@@ -1,6 +1,7 @@
 import React, { Fragment, useState, useCallback, useMemo } from "react";
 import styled from "styled-components";
-import debounce from 'lodash/debounce';
+
+import useDebounce from "hooks/use-debounce";
 
 import FlexContainer from "styles-common/flex";
 import FlexController from "styles-common/flex-controller";
@@ -52,7 +53,7 @@ const QueryLimit = ({
     [isDouble, minValue, maxValue]
   );
 
-  const onChangeDebounced = useCallback(debounce(onChange, 300), [onChange]);
+  const onChangeDebounced = useDebounce(onChange);
 
   const onChangeValue = useCallback((value) => {
     setLocalValue(value);

--- a/src/applications/widget-editor/src/components/slice-count/component.js
+++ b/src/applications/widget-editor/src/components/slice-count/component.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import debounce from 'lodash/debounce';
+
+import useDebounce from "hooks/use-debounce";
 
 import FlexContainer from "styles-common/flex";
 import FlexController from "styles-common/flex-controller";
@@ -26,9 +27,9 @@ const SliceCount = ({
     }
   }
 
-  const debounceOnChange = debounce(q => {
+  const debounceOnChange = useDebounce(q => {
     onChange(q.value, q.key);
-  }, 300);
+  });
 
   return (
     <InputGroup>

--- a/src/applications/widget-editor/src/components/slice-count/component.js
+++ b/src/applications/widget-editor/src/components/slice-count/component.js
@@ -28,7 +28,7 @@ const SliceCount = ({
 
   const debounceOnChange = debounce(q => {
     onChange(q.value, q.key);
-  }, 1000);
+  }, 300);
 
   return (
     <InputGroup>

--- a/src/applications/widget-editor/src/components/widget-info/component.js
+++ b/src/applications/widget-editor/src/components/widget-info/component.js
@@ -86,7 +86,7 @@ class WidgetInfo extends React.Component {
       category: { ...configuration.category },
       value: { ...configuration.value, format: format?.value || "s" },
     });
-  }, 1000);
+  }, 300);
 
   setTitle(title) {
     this.setState({ title });

--- a/src/applications/widget-editor/src/hooks/use-debounce.js
+++ b/src/applications/widget-editor/src/hooks/use-debounce.js
@@ -1,27 +1,13 @@
-import { useState, useEffect } from "react";
+import { useCallback } from "react";
+import debounce from 'lodash/debounce';
 
-function useDebounce(value, delay) {
-  // State and setters for debounced value
-  const [debouncedValue, setDebouncedValue] = useState(value);
-
-  useEffect(
-    () => {
-      // Update debounced value after delay
-      const handler = setTimeout(() => {
-        setDebouncedValue(value);
-      }, delay);
-
-      // Cancel the timeout if value changes (also on delay change or unmount)
-      // This is how we prevent debounced value from updating if value is changed ...
-      // .. within the delay period. Timeout gets cleared and restarted.
-      return () => {
-        clearTimeout(handler);
-      };
-    },
-    [value, delay] // Only re-call effect if value or delay changes
+function useDebounce(callback, wait = 300) {
+  const debouncedCallback = useCallback(
+    debounce((...args) => callback(...args), wait),
+    [wait],
   );
 
-  return debouncedValue;
+  return debouncedCallback;
 }
 
 export default useDebounce;

--- a/src/applications/widget-editor/src/styles-common/color-input/component.js
+++ b/src/applications/widget-editor/src/styles-common/color-input/component.js
@@ -8,7 +8,7 @@ import StyledColorInput from "./style";
 const ColorInput = ({ pickerLabel, inputLabel, value, onChange }) => {
   const [color, setColor] = useState(value);
 
-  const onChangeDebounced = useCallback(debounce(onChange, 500), [onChange]);
+  const onChangeDebounced = useCallback(debounce(onChange, 300), [onChange]);
 
   const onChangeColor = useCallback(({ target }) => {
     const value = target.value.trim();

--- a/src/applications/widget-editor/src/styles-common/color-input/component.js
+++ b/src/applications/widget-editor/src/styles-common/color-input/component.js
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from "react";
 import PropTypes from "prop-types";
-import debounce from "lodash/debounce";
+
+import useDebounce from "hooks/use-debounce";
 
 import Input from "styles-common/input";
 import StyledColorInput from "./style";
@@ -8,7 +9,7 @@ import StyledColorInput from "./style";
 const ColorInput = ({ pickerLabel, inputLabel, value, onChange }) => {
   const [color, setColor] = useState(value);
 
-  const onChangeDebounced = useCallback(debounce(onChange, 300), [onChange]);
+  const onChangeDebounced = useDebounce(onChange);
 
   const onChangeColor = useCallback(({ target }) => {
     const value = target.value.trim();


### PR DESCRIPTION
This PR reduces the debounce wait time of the UI inputs to 300ms instead of sometimes up to 1,5s.

Long wait times could get in the way of the users as they may quickly make changes and save the widget, but since the wait time wouldn't be over, the widget would be saved with stale info.

This PR also makes use of a hook with a default wait time of 300ms to standardise the use of that wait time. There was already a hook with the same name but was not in use anymore.

## Testing instructions

1. Restore this widget: `fe027675-4baf-43a8-8485-3ef8a86dc9dd` (dataset: `64c948a6-5e34-4ef2-bb69-6a6535967bd5`)
2. Make changes to the title, description or caption and quickly save

The serialised widget must contain all the changes you did (unless you didn't allow for 300ms to pass).

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175012485).
