### PR TITLE
Fix a crash when emptying “by-values” string filters

### DIFF
--- a/src/applications/widget-editor/src/components/filter/components/FilterStrings/component.js
+++ b/src/applications/widget-editor/src/components/filter/components/FilterStrings/component.js
@@ -24,7 +24,9 @@ const FilterStrings = ({ filter, onChange, ...rest }) => {
         name={`filter-string-values-${filter.id}`}
         value={(filter.value ?? []).map(value => options.find(option => option.value === value))}
         options={options}
-        onChange={selectedOptions => onChange(selectedOptions.map(({ value }) => value))}
+        onChange={selectedOptions => onChange(
+          selectedOptions === null ? [] : selectedOptions.map(({ value }) => value)
+        )}
         {...rest}
       />
     </Wrapper>


### PR DESCRIPTION
This PR fixes a crash that occurs when the user empties any “Filter by values” string filter.

## Testing instructions

1. Open the editor with the dataset `64c948a6-5e34-4ef2-bb69-6a6535967bd5`
2. Select the pie chart
3. Select the “Confidence” field for the colour select
4. Select “Fire Radiative Power (MW)” for the other select
5. Add a new filter based on the “Day or Night” field, using the “Filter by values” option
6. Select “D” as a value for the filter
7. Click the cross icon to remove “D”

The editor must not crash.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175145882).
