### PR TITLE
Remove hard-coded API URLs outside of the adapter

### DIFF
--- a/src/adapters/rw-adapter/src/index.ts
+++ b/src/adapters/rw-adapter/src/index.ts
@@ -243,6 +243,16 @@ export default class RwAdapter implements Adapter.Service {
   }
 
   /**
+   * Return the URL of the tiles of the layer
+   * @param layerId ID of the layer
+   * @param provider Provider of the layer
+   */
+  getLayerTileUrl(layerId, provider) {
+    // NOTE: this is only implemented for the providers nexgddp and gee
+    return `${this.endpoint}/layer/${layerId}/tile/${provider}/{z}/{x}/{y}`;
+  }
+
+  /**
    * Return the result of the SQL query run against the dataset
    * @param sql SQL query
    */

--- a/src/adapters/rw-adapter/src/index.ts
+++ b/src/adapters/rw-adapter/src/index.ts
@@ -231,6 +231,13 @@ export default class RwAdapter implements Adapter.Service {
     return data;
   }
 
+  async getLayer(layerId) {
+    const url = `${this.endpoint}/layer/${layerId}`;
+    const { data: { data } } = await this.prepareRequest(url);
+
+    return data;
+  }
+
   getDataUrl() {
     return `${this.endpoint}/query/${this.datasetId}?sql=${this.SQL_STRING}`
   }

--- a/src/adapters/rw-adapter/src/index.ts
+++ b/src/adapters/rw-adapter/src/index.ts
@@ -14,7 +14,6 @@ import { SerializedScheme } from "./types";
 
 export default class RwAdapter implements Adapter.Service {
   endpoint = "https://api.resourcewatch.org/v1";
-  dataEndpoint = "https://api.resourcewatch.org/v1/query";
 
   config = null;
   datasetService = null;
@@ -233,11 +232,7 @@ export default class RwAdapter implements Adapter.Service {
   }
 
   getDataUrl() {
-    return tags.oneLineTrim`
-      https://api.resourcewatch.org/v1/query/
-      ${this.datasetId}?
-      sql=${this.SQL_STRING}
-    `
+    return `${this.endpoint}/query/${this.datasetId}?sql=${this.SQL_STRING}`
   }
 
   async requestData(store: any) {

--- a/src/applications/renderer/src/components/renderer/component.js
+++ b/src/applications/renderer/src/components/renderer/component.js
@@ -17,6 +17,7 @@ const Map = React.lazy(() => import("@widget-editor/map"));
 
 // -- If a widget config is suplied, we are consuming the renderer outside of the editor
 const Renderer = ({
+  adapter,
   widget,
   editor,
   widgetConfig = null,
@@ -34,6 +35,10 @@ const Renderer = ({
     initialized && !restoring && widget && Object.keys(widget).length === 0;
 
   const isMap = configuration.visualizationType === "map";
+
+  if (typeof adapter !== "function") {
+    throw new Error("Renderer: Missing prop adapter and adapter needs to be of type Adapter");
+  }
 
   if (restoring) {
     return (
@@ -55,6 +60,7 @@ const Renderer = ({
         }
       >
         <Standalone
+          adapter={adapter}
           thumbnail={thumbnail}
           widgetConfig={widgetConfig}
           widgetName={widgetName}

--- a/src/applications/renderer/src/components/renderer/component.js
+++ b/src/applications/renderer/src/components/renderer/component.js
@@ -101,6 +101,7 @@ const Renderer = ({
         <Suspense fallback={<div>Loading...</div>}>
           {!!editor.layers && (
             <Map
+              adapter={new adapter()}
               mapConfiguration={configuration.map}
               caption={configuration.title}
               layerId={configuration.layer}

--- a/src/applications/renderer/src/components/standalone/component.js
+++ b/src/applications/renderer/src/components/standalone/component.js
@@ -8,7 +8,8 @@ import Legend from './legend';
 const Chart = React.lazy(() => import("../chart"));
 const Map = React.lazy(() => import("@widget-editor/map"));
 
-const Standalone = ({ 
+const Standalone = ({
+  adapter,
   thumbnail,
   widgetConfig,
   changeBbox,
@@ -16,7 +17,8 @@ const Standalone = ({
   widgetName
 }) => {
   const isMap = widgetConfig?.paramsConfig?.visualizationType === "map";
-  const [{ layerData, isLoadingLayers, isErrorLayers }] = useLayerData(
+  const { layerData, isLoadingLayers, isErrorLayers } = useLayerData(
+    adapter,
     widgetConfig?.paramsConfig?.layer,
     isMap
   );

--- a/src/applications/renderer/src/components/standalone/component.js
+++ b/src/applications/renderer/src/components/standalone/component.js
@@ -62,6 +62,7 @@ const Standalone = ({
       {isMap && (
         <Suspense>
           <Map
+            adapter={new adapter()}
             layerId={widgetConfig?.paramsConfig?.layer}
             thumbnail={thumbnail}
             widget={{

--- a/src/applications/renderer/src/components/standalone/fetch-layers-hook.js
+++ b/src/applications/renderer/src/components/standalone/fetch-layers-hook.js
@@ -1,31 +1,32 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 
-const useLayerData = (layerId, isMap) => {
+const useLayerData = (adapter, layerId, isMap) => {
   const [layerData, setData] = useState(null);
-  const [dataURL, setDataURL] = useState(
-    `https://api.resourcewatch.org/v1/layer/${layerId}`
-  );
 
   const [isLoadingLayers, setIsLoading] = useState(false);
   const [isErrorLayers, setIsError] = useState(false);
+
+  const adapterInstance = useMemo(() => new adapter(), [adapter]);
+
   useEffect(() => {
     const fetchData = async () => {
       setIsError(false);
       setIsLoading(true);
       try {
-        const request = await fetch(dataURL);
-        const { data } = await request.json();
+        const data = await adapterInstance.getLayer(layerId);
         setData(data);
       } catch (error) {
         setIsError(true);
       }
       setIsLoading(false);
     };
+
     if (isMap) {
       fetchData();
     }
-  }, []);
-  return [{ layerData, isLoadingLayers, isErrorLayers }, setDataURL];
+  }, [adapterInstance, layerId, isMap]);
+
+  return { layerData, isLoadingLayers, isErrorLayers };
 };
 
 export default useLayerData;

--- a/src/applications/widget-editor/README.md
+++ b/src/applications/widget-editor/README.md
@@ -70,12 +70,12 @@ import WidgetEditor, { RwAdapter } from "widget-editor";
 
 # Using the renderer
 
-The renderer allows you to render a chart based on a widget configuration. It takes one parameter, which is a widget configuration.
+The renderer allows you to render a chart based on a widget configuration.
 
 ```jsx
-import { Renderer } from "widget-editor";
+import { Renderer, RwAdapter } from "widget-editor";
 
 const App = () => {
-  return <Renderer widgetConfig={...} />;
+  return <Renderer adapter={RwAdapter} widgetConfig={...} />;
 };
 ```

--- a/src/applications/widget-editor/src/components/editor/component.js
+++ b/src/applications/widget-editor/src/components/editor/component.js
@@ -16,7 +16,7 @@ class Editor extends React.Component {
     const {
       datasetId,
       widgetId,
-      adapter,
+      adapterInstance,
       setEditor,
       dispatch,
       userPassedTheme,
@@ -28,7 +28,7 @@ class Editor extends React.Component {
     this.dataService = new DataService(
       datasetId,
       widgetId,
-      adapter,
+      adapterInstance,
       setEditor,
       dispatch
     );
@@ -40,12 +40,12 @@ class Editor extends React.Component {
 
     props.dispatch({
       type: constants.sagaEvents.DATA_FLOW_STORE_ADAPTER_CONFIG,
-      payload: adapter,
+      payload: adapterInstance,
     });
 
     // XXX: Initialize editor hooks apis
     setReduxCache(dispatch)
-    localGetEditorState({ adapter, dataService: this.dataService });
+    localGetEditorState({ adapter: adapterInstance, dataService: this.dataService });
   }
 
   UNSAFE_componentWillMount() {
@@ -152,9 +152,9 @@ class Editor extends React.Component {
   }, 1000);
 
   onSave() {
-    const { onSave, dispatch, editorState, adapter } = this.props;
+    const { onSave, dispatch, editorState, adapterInstance } = this.props;
     if (typeof onSave === "function") {
-      const outputPayload = getOutputPayload(editorState, adapter);
+      const outputPayload = getOutputPayload(editorState, adapterInstance);
       onSave(outputPayload);
     }
     dispatch({ type: constants.sagaEvents.EDITOR_SAVE });
@@ -163,13 +163,14 @@ class Editor extends React.Component {
   render() {
     const {
       adapter,
+      adapterInstance,
       theme: { compact },
     } = this.props;
     return (
       <StyledContainer {...compact}>
         <StyleEditorContainer>
-          <Renderer standalone={false} />
-          <EditorOptions adapter={adapter} dataService={this.dataService} />
+          <Renderer adapter={adapter} standalone={false} />
+          <EditorOptions adapter={adapterInstance} dataService={this.dataService} />
         </StyleEditorContainer>
         <Footer onSave={this.onSave} />
       </StyledContainer>

--- a/src/applications/widget-editor/src/components/filter/component.js
+++ b/src/applications/widget-editor/src/components/filter/component.js
@@ -5,6 +5,8 @@ import uniqueId from "lodash/uniqueId";
 import { FiltersService, constants } from "@widget-editor/core";
 import { Button } from "@widget-editor/shared";
 
+import { getLocalCache } from "exposed-hooks";
+
 import InputGroup from "styles-common/input-group";
 import { DEFAULT_FILTER_VALUE } from "./const";
 import NotNullInput from "./components/NotNullInput";
@@ -58,6 +60,8 @@ const Filter = ({
   }), [filters, setFilters]);
 
   const updateFilter = useCallback(async (filterId, change) => {
+    const { adapter } = getLocalCache();
+
     const patch = await Promise.all(filters.map(async filter => {
       if (filter.id !== filterId) {
         return filter;
@@ -67,7 +71,7 @@ const Filter = ({
         ...filter,
         ...change,
         config: !filter.column
-          ? await FiltersService.fetchConfiguration(dataset, fields, change.column)
+          ? await FiltersService.fetchConfiguration(adapter, dataset, fields, change.column)
           : filter.config,
       };
     }));

--- a/src/applications/widget-editor/src/components/widget-editor/component.js
+++ b/src/applications/widget-editor/src/components/widget-editor/component.js
@@ -34,7 +34,8 @@ class WidgetEditor extends React.Component {
         enableSave={enableSave}
         datasetId={datasetId}
         widgetId={widgetId}
-        adapter={new adapter()}
+        adapter={adapter}
+        adapterInstance={new adapter()}
         schemes={schemes}
         userPassedCompact={compact}
         userPassedTheme={theme}

--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -42,7 +42,7 @@ function* initializeData(props) {
   const widgetData = yield call(getWidgetDataWithAdapter, widgetEditor)
 
   if (widgetData) {
-    yield put(setEditor({ widgetData: widgetData.data }));
+    yield put(setEditor({ widgetData: widgetData }));
   }
 
   yield put(dataInitialized());

--- a/src/packages/core/src/charts/chart-common.ts
+++ b/src/packages/core/src/charts/chart-common.ts
@@ -103,11 +103,12 @@ export default class ChartCommon {
 
   async resolveSignals(): Promise<any[]> {
     const { editor: { dataset } } = this.store;
+    const { adapter } = getLocalCache();
 
     const endUserFilters: string[] = selectEndUserFilters(this.store);
     const fields: any[] = selectFields(this.store);
 
-    const fieldService = new FieldsService(dataset, fields);
+    const fieldService = new FieldsService(adapter, dataset, fields);
 
     const promises = await endUserFilters.map(async (fieldName) => {
       const field = fields.find(f => f.columnName === fieldName);

--- a/src/packages/core/src/filters/index.ts
+++ b/src/packages/core/src/filters/index.ts
@@ -2,6 +2,7 @@ import * as Generic from '@widget-editor/types/build/generic';
 import * as Filters from '@widget-editor/types/build/filters';
 import * as Dataset from '@widget-editor/types/build/dataset';
 import FiltersService from '../services/filters';
+import { Adapter } from '@widget-editor/types';
 
 /**
  * Serialize the editor's filters for the widgetConfig
@@ -33,11 +34,13 @@ export const getSerializedFilters = (filters: Filters.Filter[]): Filters.Seriali
 
 /**
  * Deserialize the filters for for the widget-editor's application
+ * @param adapter Adapter
  * @param filters Serialized filters
  * @param fields Dataset's fields
  * @param dataset Dataset object
  */
 export const getDeserializedFilters = async (
+  adapter: Adapter.Service,
   filters: Filters.SerializedFilter[],
   fields: Generic.Array,
   dataset: Dataset.Payload
@@ -46,5 +49,5 @@ export const getDeserializedFilters = async (
     return [];
   }
 
-  return await FiltersService.getDeserializedFilters(filters, fields, dataset);
+  return await FiltersService.getDeserializedFilters(adapter, filters, fields, dataset);
 };

--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -1,9 +1,6 @@
 import isObjectLike from "lodash/isObjectLike";
 
-import { Dataset, Widget, Adapter, Generic, Filters } from "@widget-editor/types";
-
-import FiltersService from "./filters";
-import VegaService from "./vega";
+import { Dataset, Widget, Adapter, Generic } from "@widget-editor/types";
 
 import { setAdapter } from "../helpers/adapter";
 
@@ -105,6 +102,7 @@ export default class DataService {
       }
 
       const deserializedFilters = await getDeserializedFilters(
+        this.adapter,
         filters,
         this.allowedFields,
         this.dataset
@@ -172,10 +170,10 @@ export default class DataService {
   async requestWithFilters(store: any) {
     const request = await this.adapter.requestData(store);
 
-    if (!request.data || "errors" in request) {
+    if ("errors" in request) {
       this.setEditor({ errors: ["WIDGET_DATA_UNAVAILABLE"] });
     } else {
-      this.setEditor({ widgetData: request.data });
+      this.setEditor({ widgetData: request });
     }
   }
 

--- a/src/packages/core/src/services/fields.ts
+++ b/src/packages/core/src/services/fields.ts
@@ -38,8 +38,7 @@ export default class FieldsService {
 
     const query = `SELECT MIN(${columnName}) AS min, MAX(${columnName}) AS max FROM ${tableName}`;
 
-    return <Promise<{ min: number, max: number }>>this.query(query)
-      .then((data) => (data?.length ? data[0] : {}));
+    return this.query(query).then((data) => (data?.length ? data[0] : {})) as Promise<{ min: number, max: number }>;
   }
 
   /**

--- a/src/packages/core/src/services/fields.ts
+++ b/src/packages/core/src/services/fields.ts
@@ -1,31 +1,23 @@
-import { Generic } from "@widget-editor/types";
+import { Generic, Adapter } from "@widget-editor/types";
 import { ALLOWED_FIELD_TYPES } from "../constants";
 
 export default class FieldsService {
-  dataset: any;
-  fields: Generic.Array;
+  private static NUMERIC_TYPE = "number";
+  private static COLUMN_TYPE = "string";
+  private static DATE_TYPE = "date";
 
-  NUMERIC_TYPE = "number";
-  COLUMN_TYPE = "string";
-  DATE_TYPE = "date";
-
-  constructor(dataset: any, fields: Generic.Array) {
-    this.dataset = dataset;
-    this.fields = fields;
-  }
+  constructor(
+    private adapter: Adapter.Service,
+    private dataset: any,
+    private fields: Generic.Array
+  ) { }
 
   /**
    * Return the result of the SQL query performed against the dataset
    * @param sql SQL to execute
    */
-  private query(sql: string) {
-    // FIXME: This url should come from adapter
-    return fetch(`https://api.resourcewatch.org/v1/query/${this.dataset.id}?sql=${sql}`)
-      .then((response) => {
-        if (response.status >= 400) throw new Error(response.statusText);
-        return response.json();
-      })
-      .then((jsonData) => jsonData.data);
+  private async query(sql: string) {
+    return await this.adapter.getDatasetData(sql);
   }
 
   /**
@@ -46,7 +38,7 @@ export default class FieldsService {
 
     const query = `SELECT MIN(${columnName}) AS min, MAX(${columnName}) AS max FROM ${tableName}`;
 
-    return this.query(query)
+    return <Promise<{ min: number, max: number }>>this.query(query)
       .then((data) => (data?.length ? data[0] : {}));
   }
 
@@ -81,12 +73,12 @@ export default class FieldsService {
 
     const fieldType = ALLOWED_FIELD_TYPES.find(type => type.name === field.type)?.type ?? 'string';
 
-    if (fieldType === this.NUMERIC_TYPE || fieldType === this.DATE_TYPE) {
+    if (fieldType === FieldsService.NUMERIC_TYPE || fieldType === FieldsService.DATE_TYPE) {
       const res = await this.getColumnMinAndMax(field);
       return res;
     }
 
-    if (fieldType === this.COLUMN_TYPE) {
+    if (fieldType === FieldsService.COLUMN_TYPE) {
       return {
         values: await this.getColumnValues(field)
       };

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -301,18 +301,6 @@ export default class FiltersService implements Filters.Service {
     this.sql = `${this.sql} LIMIT ${limit}`;
   }
 
-  async requestWidgetData() {
-    if (!this.dataset.id) {
-      throw new Error("Error, datasetId not present in Filters service.");
-    }
-
-    const response = await this.adapter.prepareRequest(
-      `https://api.resourcewatch.org/v1/query/${this.dataset.id}?sql=${this.sql}`
-    );
-
-    return response.data;
-  }
-
   getQuery() {
     return encodeURIComponent(this.sql.replace(/ +(?= )/g, ""));
   }

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -320,11 +320,17 @@ export default class FiltersService implements Filters.Service {
   /**
    * Return the deserialized filters allow with their configuration (values and/or minimum and
    * maximum)
+   * @param adapter Adapter
    * @param filters Serialized filters
    * @param fields Dataset's fields
    * @param dataset Dataset object
    */
-  static async getDeserializedFilters(filters: Filters.SerializedFilter[], fields: Generic.Array, dataset: any): Promise<Filters.Filter[]> {
+  static async getDeserializedFilters(
+    adapter: Adapter.Service,
+    filters: Filters.SerializedFilter[],
+    fields: Generic.Array,
+    dataset: any
+  ): Promise<Filters.Filter[]> {
     const res = [];
 
     await asyncForEach(filters, async (filter, index) => {
@@ -340,7 +346,7 @@ export default class FiltersService implements Filters.Service {
       }
 
       // Resolve metadata for current field
-      const fieldService = new FieldsService(dataset, fields);
+      const fieldService = new FieldsService(adapter, dataset, fields);
 
       let deserializedValue = value;
       if (type === 'date') {
@@ -363,12 +369,17 @@ export default class FiltersService implements Filters.Service {
 
   /**
    * Fetch the configuration of a filter i.e. it's possible values, min value, max value, etc.
+   * @param adapter Adapter
    * @param dataset Dataset object
    * @param fields The fields of the dataset
    * @param fieldName Name of the column attached to the filter
    */
-  static async fetchConfiguration(dataset: any, fields: any[], fieldName: string) {
-    const fieldService = new FieldsService(dataset, fields);
+  static async fetchConfiguration(
+    adapter: Adapter.Service,
+    dataset: any, fields: any[],
+    fieldName: string
+  ) {
+    const fieldService = new FieldsService(adapter, dataset, fields);
     const configuration = await fieldService.getFieldInfo(fieldName);
     return configuration;
   }

--- a/src/packages/map/src/helpers/layer-manager.js
+++ b/src/packages/map/src/helpers/layer-manager.js
@@ -9,6 +9,7 @@ export default class LayerManager {
     this.mapLayers = {};
     this.layersLoading = {};
     this.rejectLayersLoading = false;
+    this.adapter = options.adapter;
     this.onLayerAddedSuccess = options.onLayerAddedSuccess;
     this.onLayerAddedError = options.onLayerAddedError;
   }
@@ -86,13 +87,13 @@ export default class LayerManager {
   }
 
   addNexGDDPLayer(layerData) {
-    const tileUrl = `https://api.resourcewatch.org/v1/layer/${layerData.id}/tile/nexgddp/{z}/{x}/{y}`;
+    const tileUrl = this.adapter.getLayerTileUrl(layerData.id, 'nexgddp');
     const tileLayer = L.tileLayer(tileUrl).addTo(this.map);
     this.mapLayers[layerData.id] = tileLayer;
   }
 
   addGeeLayer(layerData) {
-    const tileUrl = `https://api.resourcewatch.org/v1/layer/${layerData.id}/tile/gee/{z}/{x}/{y}`;
+    const tileUrl = this.adapter.getLayerTileUrl(layerData.id, 'gee');
     const tileLayer = L.tileLayer(tileUrl).addTo(this.map);
     this.mapLayers[layerData.id] = tileLayer;
   }

--- a/src/packages/map/src/index.js
+++ b/src/packages/map/src/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 import { redux } from "@widget-editor/shared";
 import isEqual from "lodash/isEqual";
@@ -262,6 +263,7 @@ class Map extends React.Component {
     };
 
     this.layerManager = new LayerManager(this.map, {
+      adapter: this.props.adapter,
       onLayerAddedSuccess: stopLoading,
       onLayerAddedError: stopLoading,
     });
@@ -401,6 +403,10 @@ class Map extends React.Component {
     );
   }
 }
+
+Map.propTypes = {
+  adapter: PropTypes.object.isRequired,
+};
 
 export default redux.connectState(
   state => ({

--- a/src/packages/types/src/adapter.ts
+++ b/src/packages/types/src/adapter.ts
@@ -1,8 +1,6 @@
 import * as Dataset from "./dataset";
 import * as Widget from "./widget";
 import * as Config from "./config";
-import * as Generic from "./generic";
-import * as Filters from "./filters";
 
 type Id = string | number;
 type WidgetId = Id;
@@ -13,7 +11,6 @@ export type datasetId = Id;
 export interface Service {
   config: Config.Payload;
   endpoint: Endpoint;
-  dataEndpoint: Endpoint;
   datasetId: datasetId;
   requestQue: any;
   isAborting: boolean;

--- a/src/packages/types/src/adapter.ts
+++ b/src/packages/types/src/adapter.ts
@@ -1,5 +1,6 @@
 import * as Dataset from "./dataset";
 import * as Widget from "./widget";
+import * as Layer from "./layer";
 import * as Config from "./config";
 
 type Id = string | number;
@@ -29,6 +30,7 @@ export interface Service {
   getFields(): Promise<[object]>;
   getDataUrl(): string;
   getLayers(): Promise<[object]>;
+  getLayer(layerId: Layer.Id): Promise<Layer.Payload>;
   setDatasetId(datasetId: datasetId): void;
   getSerializedScheme(config: Widget.Scheme): any;
   getDeserializedScheme(config: any): Widget.Scheme;

--- a/src/packages/types/src/adapter.ts
+++ b/src/packages/types/src/adapter.ts
@@ -32,6 +32,7 @@ export interface Service {
   getFields(): Promise<[object]>;
   getLayers(): Promise<[object]>;
   getLayer(layerId: Layer.Id): Promise<Layer.Payload>;
+  getLayerTileUrl(layerId: Layer.Id, provider: Layer.Provider): string;
   setDatasetId(datasetId: datasetId): void;
   getSerializedScheme(config: Widget.Scheme): any;
   getDeserializedScheme(config: any): Widget.Scheme;

--- a/src/packages/types/src/adapter.ts
+++ b/src/packages/types/src/adapter.ts
@@ -20,6 +20,8 @@ export interface Service {
   // This will be grabbed and put into onSave on any request
   prepareRequest(url: string): Promise<any>;
   payload(): object;
+  getDatasetData(sql: string): Promise<Dataset.Data['data']>;
+  getDataUrl(): string;
   requestData(store: any): Promise<any>;
   getDataset(): Promise<Dataset.Payload>;
   extendProperties(prop: any): void;
@@ -28,7 +30,6 @@ export interface Service {
     widget: Widget.Id
   ): Promise<Widget.Payload>;
   getFields(): Promise<[object]>;
-  getDataUrl(): string;
   getLayers(): Promise<[object]>;
   getLayer(layerId: Layer.Id): Promise<Layer.Payload>;
   setDatasetId(datasetId: datasetId): void;

--- a/src/packages/types/src/dataset.ts
+++ b/src/packages/types/src/dataset.ts
@@ -18,6 +18,10 @@ export interface Payload {
   id: Id;
 }
 
+export interface Data {
+  data: { [key: string]: any }[];
+}
+
 export interface Service {
   fetchData(url: Url): Promise<[Dataset.Payload]>;
   fetchFilteredData?(query: Query): [object];

--- a/src/packages/types/src/dataset.ts
+++ b/src/packages/types/src/dataset.ts
@@ -1,7 +1,7 @@
 import * as Dataset from './dataset';
 import * as Widget from './widget';
 
-type Id = string | null;
+export type Id = string | null;
 type Url = string;
 type Query = string;
 type ColumnName = string;

--- a/src/packages/types/src/filters.ts
+++ b/src/packages/types/src/filters.ts
@@ -7,7 +7,6 @@ export interface Service {
   prepareGroupBy(): void;
   prepareOrderBy(): void;
   prepareLimit(): void;
-  requestWidgetData(): Promise<Generic.ObjectPayload>;
 }
 
 type GenericFilter<T> = {

--- a/src/packages/types/src/layer.ts
+++ b/src/packages/types/src/layer.ts
@@ -1,0 +1,13 @@
+import * as Dataset from './dataset';
+
+export type Id = string | null;
+
+export interface Payload {
+  id: Id;
+  attributes: {
+    name: string;
+    slug: string;
+    dataset: Dataset.Id;
+    provider: string;
+  };
+}

--- a/src/packages/types/src/layer.ts
+++ b/src/packages/types/src/layer.ts
@@ -2,6 +2,8 @@ import * as Dataset from './dataset';
 
 export type Id = string | null;
 
+export type Provider = string;
+
 export interface Payload {
   id: Id;
   attributes: {

--- a/src/playground/widget-editor/src/components/playground-renderer/component.js
+++ b/src/playground/widget-editor/src/components/playground-renderer/component.js
@@ -1,5 +1,6 @@
 import React from "react";
 
+import RwAdapter from "@widget-editor/rw-adapter";
 import Renderer from "@widget-editor/renderer";
 
 // eslint-disable-next-line
@@ -14,6 +15,7 @@ const PlaygroundRenderer = ({ activeWidget }) => {
       <div className="c-widget-block">
         <div className="renderer-wrapper">
           <Renderer
+            adapter={RwAdapter}
             thumbnail={false}
             // widgetConfig={widgetTest.data.attributes.widgetConfig}
             // widgetName={widgetTest.data.attributes.name}


### PR DESCRIPTION
In several places across the repository, hard-coded API URLs could be found. This PR makes sure the URLs are always pulled from the adapter.

⚠️ This PR contains breaking changes as the Renderer now requires the adapter class to be passed as a prop.

## Testing instructions

Here we want to test that this PR doesn't introduce any regression.

The first test consists in making sure the Renderer still works as expected:
1. Restore the widget `fe027675-4baf-43a8-8485-3ef8a86dc9dd` (dataset: `64c948a6-5e34-4ef2-bb69-6a6535967bd5`)
2. In the playground, click the “View renderer” button

The Renderer must render the widget.

The second test consists in making sure the widget data and the configuration of the filters are loaded:
1. Restore the dataset `64c948a6-5e34-4ef2-bb69-6a6535967bd5`
2. Create a bar widget with the “Acquisition Time” on the X axis and “Fire Radiative Power (MW)” on the Y one

The chart must render.

3. Add a new filter based on the column “Fire Radiative Power (MW)”, using the “Between” operation

Make sure the inputs below the slider contain a value.

The final test consists in verifying the GEE layers are still displayed on the map:
1. Restore the dataset `65c0e15b-dad0-4681-934e-91c0a378d2fb`
2. Select the map visualisation

The dataset's only layer must be displayed on the map.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175144876).
