### PR TITLE
Fix wrong implementation of the end-user filters

### DIFF
--- a/src/applications/widget-editor/src/components/end-user-filters/component.js
+++ b/src/applications/widget-editor/src/components/end-user-filters/component.js
@@ -27,8 +27,8 @@ const EndUserFilters = ({
   );
 
   const value = useMemo(
-    () => endUserFilters.map(str => ({ label: str, value: str})),
-    [endUserFilters],
+    () => endUserFilters.map(endUserFilter => fields.find(f => f.value === endUserFilter)),
+    [fields, endUserFilters],
   );
 
   const onChangeColumns = useCallback((options) => {

--- a/src/packages/core/src/charts/chart-common.ts
+++ b/src/packages/core/src/charts/chart-common.ts
@@ -109,15 +109,17 @@ export default class ChartCommon {
 
     const fieldService = new FieldsService(dataset, fields);
 
-    const promises = await endUserFilters.map(async (fieldName) => {
+    const promises = await endUserFilters.map(async (fieldName, index) => {
       const field = fields.find(f => f.columnName === fieldName);
       const type = constants.ALLOWED_FIELD_TYPES.find(type => type.name === field.type)?.type
         ?? 'string';
 
       const signal = {
-        name: field.metadata && field.metadata.alias ? field.metadata.alias : field.columnName,
+        name: `endUserFilter${index}`,
         value: null,
-        bind: {},
+        bind: {
+          name: field.metadata && field.metadata.alias ? field.metadata.alias : field.columnName,
+        } as { [key: string]: any },
       };
 
       switch (type) {
@@ -125,6 +127,7 @@ export default class ChartCommon {
           const options = await fieldService.getColumnValues(field);
           signal.value = options.length ? options[0] : null;
           signal.bind = {
+            ...signal.bind,
             input: 'select',
             options,
           };
@@ -135,6 +138,7 @@ export default class ChartCommon {
           const { min, max } = await fieldService.getColumnMinAndMax(field);
           signal.value = min;
           signal.bind = {
+            ...signal.bind,
             input: 'range',
             min,
             max,
@@ -147,6 +151,7 @@ export default class ChartCommon {
           const { min, max } = await fieldService.getColumnMinAndMax(field);
           signal.value = new Date(min).toISOString().split('T')[0];
           signal.bind = {
+            ...signal.bind,
             input: 'date',
             min: new Date(min).toISOString().split('T')[0],
             max: new Date(max).toISOString().split('T')[0],
@@ -174,9 +179,7 @@ export default class ChartCommon {
         type: 'filter',
         expr: endUserFilters.reduce((res, fieldName, index) => {
           const field = fields.find(f => f.columnName === fieldName);
-          const signal = field.metadata && field.metadata.alias
-            ? field.metadata.alias
-            : field.columnName;
+          const signal = `endUserFilter${index}`;
           const type = constants.ALLOWED_FIELD_TYPES.find(type => type.name === field.type)?.type
             ?? 'string';
 


### PR DESCRIPTION
The end-user filters were wrongly implemented in #108: the names of the columns would be used as the names of the signals, but only names valid as Javascript variables would be accepted.

This PR names all the signals of the end-user filters `endUserFilterX` where X is their index number to avoid generating wrong Vega configurations.

In addition, this PR fixes a minor issue where the names of the columns used by the filters wouldn't be displayed with their aliases in the UI.

## Testing instructions

1. Restore the dataset `64c948a6-5e34-4ef2-bb69-6a6535967bd5`
2. Create a bar chart with “Acquisition Time” on the X axis and “Fire Radiation Power (MW)” on the Y axis
3. Add two end-user filters: one based on the column “Confidence” and the other on “Day or Night”

At this point, two filters must appear below the chart, and no error must be present in the console. The selected columns in the select must also be displayed with their aliases: “Confidence” and “Day or Night”.

## Pivotal Tracker

Not tracked.
