### PR TITLE
Fix a crash when all the visualisation types are disabled

### DIFF
--- a/src/applications/renderer/src/components/select-chart/components/ChartMenu/component.js
+++ b/src/applications/renderer/src/components/select-chart/components/ChartMenu/component.js
@@ -30,10 +30,10 @@ const ChartList = ({ list, setData, title }) => {
  * @param {options} - the array of available charts
  */
 const ChartMenu = ({ options, getValue, setValue, innerRef, innerProps }) => {
-  const data = getValue()[0];
+  const data = getValue()[0]; // Data may be null if all the visualization types are disabled
   const menu = MENU_DATA.map(menu => ({
     ...menu,
-    active: menu.type === data.chartType,
+    active: data ? menu.type === data.chartType : null,
     disabled: !options.find(o => o.chartType === menu.type),
   }));
 


### PR DESCRIPTION
When all the visualisation types are disabled, and the user would click the visualisation select, the editor would crash. This PR prevents the crash from happening.

## Testing instructions

1. Restore the widget `1ae4b9db-93b9-4b2f-8bdb-b9341627703d` (dataset: `b75d8398-34f2-447d-832d-ea570451995a`)
2. In `src/playground/widget-editor/src/components/editor/component.js`, replace the `disable`'s prop value by `['typography', 'map']` (disabling the map)
3. Open the playground
4. Click the visualisation select

The editor must not crash.

## Pivotal Tracker

Reported on [this task](https://www.pivotaltracker.com/story/show/174639931) but not part of it. The task is related to a wrong RW configuration.
