### PR TITLE
Improve the size and layout of the editor

### DIFF
--- a/src/applications/renderer/src/components/chart-title/style.js
+++ b/src/applications/renderer/src/components/chart-title/style.js
@@ -1,8 +1,9 @@
 import styled from "styled-components";
 
 export const StyledTitle = styled.h3`
+  flex-shrink: 0;
+  padding: 5px 0 0 0;
   color: #393F44;
   font-size: 16px;
   text-align: center;
-  padding: 20px 0 0 0;
 `;

--- a/src/applications/renderer/src/components/chart/styles.js
+++ b/src/applications/renderer/src/components/chart/styles.js
@@ -11,11 +11,11 @@ export const ChartNeedsOptions = styled.h4`
 export const StyledContainer = styled.div`
   ${(props) => !props.standalone && css`
     position: relative;
-    flex: 1;
+    overflow: hidden;
     flex-grow: 1;
+    flex-shrink: 1;
     width: 100%;
-    padding: 15px 20px 65px ${props.hasYAxis ? '65px' : '20px'};
-    box-sizing: border-box;
+    padding: 15px 10px 55px ${props.hasYAxis ? '60px' : '20px'};
   `}
 
   ${(props) => (props.standalone || props.thumbnail) && css`

--- a/src/applications/renderer/src/components/column-selections/style.js
+++ b/src/applications/renderer/src/components/column-selections/style.js
@@ -6,15 +6,15 @@ const SELECT_WIDTH = 250;
 
 export const StyledBottomSelect = styled.div`
   position: absolute;
-  bottom: 10px;
-  left: ${props => props.hasYAxis ? 'calc((100% - 65px - 20px) / 2 + 65px)' : '50%'};
+  bottom: 5px;
+  left: ${props => props.hasYAxis ? 'calc((100% - 60px - 20px) / 2 + 60px)' : '50%'};
   transform: translateX(-50%);
   width: ${SELECT_WIDTH}px;
 `;
 
 export const StyledLeftSelect = styled.div`
   position: absolute;
-  bottom: calc((100% - 65px - 15px) / 2 + 65px);
+  bottom: calc((100% - 55px - 15px) / 2 + 55px);
   left: 10px;
   transform: translateY(50%) rotate(-90deg) translateY(calc(-${SELECT_WIDTH / 2}px + (45px / 2)));
   transform-origin: center;
@@ -56,7 +56,6 @@ export const SelectStyles = {
       boxShadow: "0 20px 30px 0 rgba(0,0,0,0.1)",
       transform: state.selectProps.position === "left" ? "rotate(90deg) translateX(100%)" : "null",
       transformOrigin: state.selectProps.position === "left" ? "top right" : "null",
-      boxSizing: "border-box",
       zIndex: 1,
       ':before': {
         content: "''",

--- a/src/applications/renderer/src/components/legend/style.js
+++ b/src/applications/renderer/src/components/legend/style.js
@@ -64,13 +64,12 @@ export const StyledColorDot = styled.span`
 `;
 
 export const StyledContainer = styled.div`
+  flex-shrink: 0;
   display: flex;
   justify-content: space-between;
-  box-sizing: border-box;
-  border-top: 1px solid #d7d7d7;
   width: 100%;
-  min-height: 55px;
-  padding: 15px 36px;
+  padding: 10px;
+  border-top: 1px solid #d7d7d7;
 `;
 
 export const SelectStyles = {
@@ -106,7 +105,6 @@ export const SelectStyles = {
       boxShadow: "0 20px 30px 0 rgba(0,0,0,0.1)",
       transform: state.selectProps.position === "left" ? "rotate(90deg) translateX(100%)" : "null",
       transformOrigin: state.selectProps.position === "left" ? "top right" : "null",
-      boxSizing: "border-box",
       zIndex: 1,
       ':before': {
         content: "''",

--- a/src/applications/renderer/src/components/renderer/style.js
+++ b/src/applications/renderer/src/components/renderer/style.js
@@ -4,18 +4,11 @@ import { DEFAULT_BORDER } from "@widget-editor/shared/lib/styles/style-constants
 export const StyledContainer = styled.div`
   position: relative;
   display: flex;
-  flex-shrink: 1;
-  flex-grow: 1;
   flex-flow: column;
+  width: 100%;
+  height: 100%;
   background: #fff;
-  flex: 0 0 50%;
-  width: 50%;
-  ${(props) =>
-    props.compact &&
-    `
-    flex: 0 0 100%;
-    width: 100%;
-    `}
+
   ${DEFAULT_BORDER()}
 `;
 

--- a/src/applications/renderer/src/components/select-chart/components/ChartIcon/style.js
+++ b/src/applications/renderer/src/components/select-chart/components/ChartIcon/style.js
@@ -1,13 +1,11 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 export const StyledBox = styled.div`
-  box-sizing: border-box;
   padding: 7px 8px;
   width: 50%;
 `;
 
 export const StyledIcon = styled.div`
-  box-sizing: border-box;
   height: 51px;
   width: 100%;
   border: ${props => props.active ? '2px solid #C32D7B' : '1px solid #E6E6E6'};

--- a/src/applications/renderer/src/components/select-chart/components/ChartMenu/style.js
+++ b/src/applications/renderer/src/components/select-chart/components/ChartMenu/style.js
@@ -15,7 +15,6 @@ export const StyledContainer = styled.div`
 `;
 
 export const StyledMenu = styled.div`
-  box-sizing: border-box;
   height: auto;
   max-height: 460px;
   width: 100%;

--- a/src/applications/renderer/src/components/select-chart/style.js
+++ b/src/applications/renderer/src/components/select-chart/style.js
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 
 export const StyledContainer = styled.div`
+  flex-shrink: 0;
   margin: 10px;
   ${(props) =>
     (props.isCompact || props.forceCompact) &&

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -42,11 +42,12 @@ const StyleEditorOptionsInfo = styled.div`
 const StyledContainer = styled.div`
   position: relative;
   flex: 1;
-  padding: 0 0 0 30px;
+  padding: 0 0 0 20px;
   margin: 10px 0;
   height: calc(100% - 20px);
   overflow-y: hidden;
   ${DEFAULT_BORDER(1, 1, 1, 0)}
+
   ${(props) =>
     (props.compact.isCompact || props.compact.forceCompact) &&
     css`

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -11,10 +11,7 @@ import QueryLimit from "components/query-limit";
 import Filter from "components/filter";
 import EndUserFilters from "components/end-user-filters";
 
-import {
-  FOOTER_HEIGHT,
-  DEFAULT_BORDER,
-} from "@widget-editor/shared/lib/styles/style-constants";
+import { DEFAULT_BORDER } from "@widget-editor/shared/lib/styles/style-constants";
 
 const AdvancedEditor = React.lazy(() => import("../advanced-editor"));
 const TableView = React.lazy(() => import("../table-view"));
@@ -48,30 +45,13 @@ const StyledContainer = styled.div`
   overflow-y: hidden;
   ${DEFAULT_BORDER(1, 1, 1, 0)}
 
-  ${(props) =>
-    (props.compact.isCompact || props.compact.forceCompact) &&
-    css`
-      visibility: hidden;
-      /* z-index: -1; */
-      max-height: 0;
-      position: absolute;
-      top: 65px;
-      left: 0;
-      margin: 0;
-      width: 100%;
-      background: #fff;
-      transition: all 0.3s ease-in-out;
-    `}
-  ${(props) =>
-    (props.compact.isCompact || props.compact.forceCompact) &&
-    props.compact.isOpen &&
-    css`
-      box-sizing: border-box;
-      display: block;
-      z-index: 2;
-      visibility: visible;
-      max-height: calc(100% - ${FOOTER_HEIGHT} - 65px);
-    `}
+  ${(props) => (props.compact.isCompact || props.compact.forceCompact) && css`
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    ${DEFAULT_BORDER(1, 0, 0, 0)}
+    box-shadow: none;
+  `}
 `;
 
 const EditorOptions = ({

--- a/src/applications/widget-editor/src/components/editor/component.js
+++ b/src/applications/widget-editor/src/components/editor/component.js
@@ -138,7 +138,7 @@ class Editor extends React.Component {
 
   // We debounce all properties here
   // Then we dont have to care if debouncing is set on the client
-  resolveTheme = debounce((userPassedTheme) => {
+  resolveTheme = (userPassedTheme) => {
     const { setTheme, userPassedCompact } = this.props;
     setTheme({
       ...userPassedTheme,
@@ -147,7 +147,7 @@ class Editor extends React.Component {
         forceCompact: userPassedCompact || false,
       },
     });
-  }, 1000);
+  };
 
   resolveSchemes = debounce((schemes) => {
     const { setSchemes } = this.props;
@@ -174,10 +174,10 @@ class Editor extends React.Component {
     return (
       <StyledContainer {...compact}>
         <StyleEditorContainer>
-          <StyledRendererContainer>
+          <StyledRendererContainer {...compact}>
             <Renderer adapter={adapter} standalone={false} />
           </StyledRendererContainer>
-          <StyledOptionsContainer>
+          <StyledOptionsContainer {...compact}>
             <EditorOptions adapter={adapterInstance} dataService={this.dataService} />
           </StyledOptionsContainer>
         </StyleEditorContainer>

--- a/src/applications/widget-editor/src/components/editor/component.js
+++ b/src/applications/widget-editor/src/components/editor/component.js
@@ -6,7 +6,12 @@ import EditorOptions from "components/editor-options";
 import Footer from "components/footer";
 import { DataService, getOutputPayload } from "@widget-editor/core";
 import { constants } from "@widget-editor/core";
-import { StyledContainer, StyleEditorContainer } from "./style";
+import {
+  StyledContainer,
+  StyleEditorContainer,
+  StyledRendererContainer,
+  StyledOptionsContainer,
+} from "./style";
 
 import { localGetEditorState, setReduxCache } from "exposed-hooks";
 
@@ -169,8 +174,12 @@ class Editor extends React.Component {
     return (
       <StyledContainer {...compact}>
         <StyleEditorContainer>
-          <Renderer adapter={adapter} standalone={false} />
-          <EditorOptions adapter={adapterInstance} dataService={this.dataService} />
+          <StyledRendererContainer>
+            <Renderer adapter={adapter} standalone={false} />
+          </StyledRendererContainer>
+          <StyledOptionsContainer>
+            <EditorOptions adapter={adapterInstance} dataService={this.dataService} />
+          </StyledOptionsContainer>
         </StyleEditorContainer>
         <Footer onSave={this.onSave} />
       </StyledContainer>

--- a/src/applications/widget-editor/src/components/editor/style.js
+++ b/src/applications/widget-editor/src/components/editor/style.js
@@ -3,8 +3,12 @@ import { FOOTER_HEIGHT } from "@widget-editor/shared/lib/styles/style-constants"
 
 export const StyledContainer = styled.div`
   width: 100%;
-  height: 100%;
-  min-height: 740px;
+  max-width: 1060px;
+
+  * {
+    box-sizing: border-box;
+  }
+
   ${(props) =>
     props.isCompact || props.forceCompact
       ? css`
@@ -27,5 +31,18 @@ export const StyledContainer = styled.div`
 export const StyleEditorContainer = styled.div`
   display: flex;
   width: 100%;
-  height: 660px;
+  height: 500px;
+`;
+
+export const StyledRendererContainer = styled.div`
+  flex-basis: 520px;
+  max-width: 520px;
+  flex-shrink: 1;
+  height: 100%;
+`;
+
+export const StyledOptionsContainer = styled.div`
+  flex-basis: 540px;
+  max-width: 540px;
+  height: 100%;
 `;

--- a/src/applications/widget-editor/src/components/editor/style.js
+++ b/src/applications/widget-editor/src/components/editor/style.js
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
-import { FOOTER_HEIGHT } from "@widget-editor/shared/lib/styles/style-constants";
 
 export const StyledContainer = styled.div`
+  position: relative;
   width: 100%;
   max-width: 1060px;
 
@@ -9,23 +9,12 @@ export const StyledContainer = styled.div`
     box-sizing: border-box;
   }
 
-  ${(props) =>
-    props.isCompact || props.forceCompact
-      ? css`
-          box-sizing: border-box;
-          position: relative;
-          margin: 0 auto;
-          height: calc(100% - ${FOOTER_HEIGHT});
-        `
-      : css`
-          display: flex;
-          flex-flow: wrap;
-          justify-content: space-between;
-          flex-flow: column;
-          @media only screen and (min-width: 768px) {
-            flex-flow: wrap;
-          }
-        `}
+  ${props => props.isCompact || props.forceCompact
+    ? css`
+        max-width: 520px;
+      `
+    : null
+  }
 `;
 
 export const StyleEditorContainer = styled.div`
@@ -45,4 +34,22 @@ export const StyledOptionsContainer = styled.div`
   flex-basis: 540px;
   max-width: 540px;
   height: 100%;
+
+  ${props => props.isCompact  || props.forceCompact
+    ? css`
+        position: absolute;
+        top: 65px;
+        left: 1px;
+        width: calc(100% - 2px);
+        height: calc(500px - 66px);
+        visibility: hidden;
+        background: white;
+
+        ${props => props.isOpen && css`
+          z-index: 2;
+          visibility: visible;
+        `}
+      `
+    : null
+  }
 `;

--- a/src/applications/widget-editor/src/components/footer/component.js
+++ b/src/applications/widget-editor/src/components/footer/component.js
@@ -1,23 +1,15 @@
-import React, { useState, Fragment } from "react";
+import React from "react";
 import styled, { css } from "styled-components";
 
 import { Button } from "@widget-editor/shared";
 
-import { FOOTER_HEIGHT } from "@widget-editor/shared/lib/styles/style-constants";
-
 const StyledFooter = styled.footer`
-  ${(props) =>
-    props.disabled &&
-    css`
-      display: none;
-    `}
   width: 100%;
-  height: ${FOOTER_HEIGHT};
-  align-self: flex-end;
+  margin-top: 20px;
 
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  ${(props) => props.disabled && css`
+    display: none;
+  `}
 `;
 
 const Footer = ({ enableSave, onSave }) => {

--- a/src/applications/widget-editor/src/components/table-view/style.js
+++ b/src/applications/widget-editor/src/components/table-view/style.js
@@ -2,8 +2,6 @@ import styled from "styled-components";
 
 export const StyledTableBox = styled.div`
   width: 100%;
-  max-height: 540px;
-  overflow: auto;
   border: 1px solid rgba(26, 28, 34, 0.1);
   margin-bottom: 20px;
 `;

--- a/src/applications/widget-editor/src/components/tabs/component.js
+++ b/src/applications/widget-editor/src/components/tabs/component.js
@@ -12,13 +12,13 @@ const TabButton = (props) => {
   return <Button style={{ height: "100%" }} {...props} />;
 };
 
-export const Tabs = ({ children }) => {
+export const Tabs = ({ theme, children }) => {
   const validChildren = useMemo(() => children.filter(c => !!c), [children]);
   const [activeId, setActiveId] = useState(validChildren[0].props.id);
 
   return (
     <StyledTabsContainer>
-      <StyledList>
+      <StyledList {...theme}>
         {validChildren.map(({ props: { id, label } }) => label
           ? (
             <StyledListLabel key={id}>
@@ -30,7 +30,7 @@ export const Tabs = ({ children }) => {
           : null
         )}
       </StyledList>
-      <StyledTabsContentBox>
+      <StyledTabsContentBox {...theme}>
         {validChildren.map(({ props: { id, children: content } }) => (
           <StyledTabsContent key={id} active={id === activeId}>
             {content}

--- a/src/applications/widget-editor/src/components/tabs/index.js
+++ b/src/applications/widget-editor/src/components/tabs/index.js
@@ -1,1 +1,10 @@
-export * from './component';
+import { connectState } from "@widget-editor/shared/lib/helpers/redux";
+import * as components from './component';
+
+export const Tabs = connectState(
+  state => ({
+    theme: state.theme,
+  }),
+)(components.Tabs);
+
+export const Tab = components.Tab;

--- a/src/applications/widget-editor/src/components/tabs/style.js
+++ b/src/applications/widget-editor/src/components/tabs/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const StyledTabsContainer = styled.div`
   position: relative;
@@ -9,6 +9,11 @@ export const StyledTabsContentBox = styled.div`
   overflow-y: auto;
   height: calc(100% - 80px);
   padding-right: 30px;
+
+  ${(props) => (props.compact.isCompact || props.compact.forceCompact) && css`
+    height: calc(100% - 65px);
+    padding: 0 10px;
+  `}
 
 
   ::-webkit-scrollbar {
@@ -40,6 +45,10 @@ export const StyledList = styled.ul`
   justify-content: flex-start;
   padding: 20px 30px 20px 0;
   list-style: none;
+
+  ${(props) => (props.compact.isCompact || props.compact.forceCompact) && css`
+    padding: 10px;
+  `}
 `;
 
 export const StyledListLabel = styled.li`

--- a/src/packages/shared/src/components/select/style.js
+++ b/src/packages/shared/src/components/select/style.js
@@ -4,8 +4,8 @@ import styled, { css } from "styled-components";
 import { AccordionArrowIcon, CloseIcon } from "components/icons";
 
 export const StyledDropdownIndicator = styled(props => <AccordionArrowIcon {...props} />)`
-  width: 16px;
-  height: 16px;
+  width: 32px;
+  height: 32px;
   padding: 8px;
   stroke: #c32d7b;
 `;

--- a/src/packages/shared/src/styles/style-constants.js
+++ b/src/packages/shared/src/styles/style-constants.js
@@ -1,5 +1,3 @@
-export const FOOTER_HEIGHT = "100px";
-
 export const DEFAULT_BORDER = (top = 1, right = 1, bottom = 1, left = 1) => `
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.09);
 
@@ -12,7 +10,6 @@ export const DEFAULT_BORDER = (top = 1, right = 1, bottom = 1, left = 1) => `
 export const COLOR_WHITE = '#ffffff';
 
 export default {
-  FOOTER_HEIGHT,
   DEFAULT_BORDER,
   COLOR_WHITE
 };

--- a/src/playground/widget-editor/src/App.scss
+++ b/src/playground/widget-editor/src/App.scss
@@ -82,9 +82,15 @@
 }
 
 .widget-editor-wrapper {
-  width: calc(100vw - 40px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: calc(100vh - 60px);
+  min-height: 600px;
   padding: 20px;
   background-color: #f1f1f1;
+  box-sizing: border-box;
 }
 
 .renderer-wrapper {


### PR DESCRIPTION
This PR improves the size and layout of the widget-editor.

<p align="center">
<img width="1115" alt="Screenshot of the smaller editor" src="https://user-images.githubusercontent.com/6073968/96456288-36a07d00-1216-11eb-9ad0-7e235aec7a97.png">
</p>

The height of the editor is now fixed (500px for the main content) and its width is no more than 1060px. Further adjustments have been made to the spacing of the renderer to avoid shrinking the visualisation too much.

## Testing instructions

Make sure the editor looks good in both “normal” and compact mode.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175044741).
