### PR TITLE
Improve the layout of the settings for editors narrower than 1060px

### DIFF
--- a/src/applications/widget-editor/src/components/accordion/style.js
+++ b/src/applications/widget-editor/src/components/accordion/style.js
@@ -5,7 +5,6 @@ import { AccordionArrowIcon } from "@widget-editor/shared"
 
 export const StyledAccordion = styled.div`
   width: 100%;
-  padding-top: 24px;
   padding-bottom: 24px;
 `;
 

--- a/src/applications/widget-editor/src/components/advanced-editor/style.js
+++ b/src/applications/widget-editor/src/components/advanced-editor/style.js
@@ -5,6 +5,8 @@ import { Button } from "@widget-editor/shared";
 import { StyledCallout } from "components/callout/style";
 
 export const Container = styled.div`
+  margin-top: 11px;
+
   label {
     margin-top: 20px;
   }

--- a/src/applications/widget-editor/src/components/color-schemes/style.js
+++ b/src/applications/widget-editor/src/components/color-schemes/style.js
@@ -21,14 +21,10 @@ export const StyledSchemesCardWrapper = styled.div`
 `;
 
 export const StyledSchemesCard = styled.div`
-  flex-basis: calc((100% / 3) - (20px / 3));
-  margin: 0 5px 10px;
+  flex-basis: calc((100% / 2) - (10px / 2));
+  margin: 0 10px 10px 0;
 
-  &:nth-of-type(3n + 1) {
-    margin-left: 0;
-  }
-
-  &:nth-of-type(3n + 3) {
+  &:nth-of-type(2n + 2) {
     margin-right: 0;
   }
 
@@ -52,7 +48,7 @@ export const StyledCardBox = styled.div`
   padding: 15px 18px;
 
   &:hover {
-    border: 2px solid #c32d7b;
+    border-color: #c32d7b;
     cursor: pointer;
   }
 `;
@@ -95,15 +91,10 @@ export const StyledCustomSchemeWrapper = styled.fieldset`
     justify-content: space-between;
 
     ${StyledColorInput} {
-      margin: 0 5px 10px;
-      margin-bottom: 10px;
-      flex-basis: calc((100% / 3) - (20px / 3));
+      margin: 0 10px 10px 0;
+      flex-basis: calc((100% / 2) - (10px / 2));
 
-      &:nth-of-type(3n + 1) {
-        margin-left: 0;
-      }
-
-      &:nth-of-type(3n + 3) {
+      &:nth-of-type(2n + 2) {
         margin-right: 0;
       }
 

--- a/src/applications/widget-editor/src/components/donut-radius/component.js
+++ b/src/applications/widget-editor/src/components/donut-radius/component.js
@@ -34,16 +34,17 @@ const DonutRadius = ({
     <InputGroup>
       <FormLabel htmlFor="options-donut-radius">Donut radius</FormLabel>
       <FlexContainer row={true}>
-        <FlexController contain={20}>
+        <FlexController shrink="0">
           <Input
             value={`${localValue.value}`}
             type="number"
             id="options-donut-radius"
             name="options-donut-radius"
+            size="4"
             onChange={value => changeValue({ value, key: "donut-radius" })}
           />
         </FlexController>
-        <FlexController contain={80}>
+        <FlexController grow="1">
           <Slider
             min={min}
             max={max}

--- a/src/applications/widget-editor/src/components/editor/style.js
+++ b/src/applications/widget-editor/src/components/editor/style.js
@@ -25,14 +25,14 @@ export const StyleEditorContainer = styled.div`
 
 export const StyledRendererContainer = styled.div`
   flex-basis: 520px;
-  max-width: 520px;
+  max-width: calc((100% - 20px) / 2);
   flex-shrink: 1;
   height: 100%;
 `;
 
 export const StyledOptionsContainer = styled.div`
-  flex-basis: 540px;
-  max-width: 540px;
+  flex-basis: calc((100% - 20px) / 2 + 20px);
+  max-width: calc((100% - 20px) / 2 + 20px);
   height: 100%;
 
   ${props => props.isCompact  || props.forceCompact

--- a/src/applications/widget-editor/src/components/order-values/component.js
+++ b/src/applications/widget-editor/src/components/order-values/component.js
@@ -85,7 +85,7 @@ const OrderValues = ({
       <InputGroup>
         <FormLabel htmlFor="options-order-title">Order by</FormLabel>
         <FlexContainer row={true}>
-          <FlexController contain={90}>
+          <FlexController grow="1" constrainElement="100">
             <Select
               formatOptionLabel={(...props) => formatOptionLabel(
                 // The aggregation is only applied to the value column
@@ -98,7 +98,7 @@ const OrderValues = ({
               isClearable
             />
           </FlexController>
-          <FlexController contain={10}>
+          <FlexController shrink="0">
             <ToggleOrder
               options={ORDER_TYPES}
               order={selectedOrder}

--- a/src/applications/widget-editor/src/components/query-limit/component.js
+++ b/src/applications/widget-editor/src/components/query-limit/component.js
@@ -63,7 +63,7 @@ const QueryLimit = ({
 
       {!isFilter && (
         <FlexContainer row={true}>
-          <FlexController contain={20}>
+          <FlexController shrink="0">
             <Input
               {...minMaxProps}
               step={isFloatingPoint ? 0.1 : 1}
@@ -71,10 +71,11 @@ const QueryLimit = ({
               type={dateType ? "date" : "number"}
               id="options-limit-max"
               name="options-limit-max"
+              size="4"
               onChange={value => onChangeValue(isDouble ? [min, +value] : +value)}
             />
           </FlexController>
-          <FlexController contain={80}>
+          <FlexController  grow="1">
             <Slider
               {...minMaxProps}
               step={isFloatingPoint ? 0.1 : 1}
@@ -89,7 +90,7 @@ const QueryLimit = ({
       {isFilter && (
         <Fragment>
           <FlexContainer row={true}>
-            <FlexController contain={100}>
+            <FlexController contain={100} constrainElement={100}>
               <RangeWrapper>
                 <Slider
                   {...minMaxProps}
@@ -102,7 +103,7 @@ const QueryLimit = ({
             </FlexController>
           </FlexContainer>
           <FlexContainer row={true}>
-            <FlexController contain={50} constrainElement={40}>
+            <FlexController>
               {isDouble && (
                 <Input
                   {...minMaxProps}
@@ -111,15 +112,12 @@ const QueryLimit = ({
                   type={dateType ? "date" : "number"}
                   name="options-limit-min"
                   id="options-limit-min"
+                  size={dateType ? undefined : `${Math.max(minMaxProps.min, minMaxProps.max)}`.length + 1}
                   onChange={value => onChangeValue([+value, maxValue])}
                 />
             )}
             </FlexController>
-            <FlexController
-              contain={50}
-              constrainElement={40}
-              alignment="right"
-            >
+            <FlexController alignment="right">
               <Input
                 {...minMaxProps}
                 step={isFloatingPoint ? 0.1 : 1}
@@ -127,6 +125,7 @@ const QueryLimit = ({
                 type={dateType ? "date" : "number"}
                 name="options-limit-max"
                 id="options-limit-max"
+                size={dateType ? undefined : `${Math.max(minMaxProps.min, minMaxProps.max)}`.length + 1}
                 onChange={value => onChangeValue(isDouble ? [minValue, +value] : +value)}
               />
             </FlexController>

--- a/src/applications/widget-editor/src/components/slice-count/component.js
+++ b/src/applications/widget-editor/src/components/slice-count/component.js
@@ -37,7 +37,7 @@ const SliceCount = ({
         Slice count (donut and pie charts)
       </FormLabel>
       <FlexContainer row={true}>
-        <FlexController contain={20}>
+        <FlexController shrink="0">
           <Input
             value={`${localValue.value}`}
             type="number"
@@ -45,12 +45,13 @@ const SliceCount = ({
             name="options-slice-count"
             onChange={value => changeValue({ value, key: "slice-count" })}
             aria-describedby="options-slice-count-info"
+            size="3"
           />
         </FlexController>
-        <FlexController contain={80}>
+        <FlexController grow="1">
           <Slider
             min={min}
-            max={10} // TODO: Can we be dynamic with this?
+            max={10}
             value={localValue.value}
             onChange={(v) => changeValue({ value: v, key: null })}
           />

--- a/src/applications/widget-editor/src/components/table-view/style.js
+++ b/src/applications/widget-editor/src/components/table-view/style.js
@@ -2,8 +2,8 @@ import styled from "styled-components";
 
 export const StyledTableBox = styled.div`
   width: 100%;
+  margin: 11px 0 20px;
   border: 1px solid rgba(26, 28, 34, 0.1);
-  margin-bottom: 20px;
 `;
 
 export const StyledTable = styled.table`

--- a/src/applications/widget-editor/src/components/tabs/style.js
+++ b/src/applications/widget-editor/src/components/tabs/style.js
@@ -43,7 +43,7 @@ export const StyledTabsContent = styled.div`
 export const StyledList = styled.ul`
   display: flex;
   justify-content: flex-start;
-  padding: 20px 30px 20px 0;
+  padding: 20px 30px 10px 0;
   list-style: none;
 
   ${(props) => (props.compact.isCompact || props.compact.forceCompact) && css`

--- a/src/applications/widget-editor/src/components/toggle-order/index.js
+++ b/src/applications/widget-editor/src/components/toggle-order/index.js
@@ -1,16 +1,17 @@
-import React, { Fragment } from "react";
+import React from "react";
 import styled, { css } from "styled-components";
 
 import { ArrowIcon } from "@widget-editor/shared";
 
 const StyledButton = styled.button`
-  border: 1px solid rgba(202, 204, 208, 0.85);
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 50px;
   padding: 13px 0;
-  cursor: pointer;
   border-radius: 5px;
+  border: 1px solid rgba(202, 204, 208, 0.85);
+  cursor: pointer;
   outline: none;
 
   &:focus {

--- a/src/applications/widget-editor/src/components/widget-info/component.js
+++ b/src/applications/widget-editor/src/components/widget-info/component.js
@@ -2,6 +2,7 @@ import React from "react";
 import isEqual from "lodash/isEqual";
 
 import FlexContainer from "styles-common/flex";
+import FlexController from "styles-common/flex-controller";
 import InputInfo from "styles-common/input-info";
 import FormLabel from "styles-common/form-label";
 import InputGroup from "styles-common/input-group";
@@ -170,28 +171,32 @@ class WidgetInfo extends React.Component {
         </InputGroup>
         {!isMap && !advanced && (
           <FlexContainer row={true}>
-            <InputGroup>
-              <FormLabel htmlFor="options-value">Value</FormLabel>
-              <Input
-                type="text"
-                placeholder="Overwrite value axis name"
-                id="options-value"
-                name="options-value"
-                value={yAxisTitle}
-                onChange={this.setYAxis}
-              />
-            </InputGroup>
-            <InputGroup>
-              <FormLabel htmlFor="options-category">Category</FormLabel>
-              <Input
-                type="text"
-                placeholder="Overwrite category axis name"
-                id="options-category"
-                name="options-category"
-                value={xAxisTitle}
-                onChange={this.setXAxis}
-              />
-            </InputGroup>
+            <FlexController contain={50} shrink={1}>
+              <InputGroup>
+                <FormLabel htmlFor="options-value">Value</FormLabel>
+                <Input
+                  type="text"
+                  placeholder="Overwrite value axis name"
+                  id="options-value"
+                  name="options-value"
+                  value={yAxisTitle}
+                  onChange={this.setYAxis}
+                />
+              </InputGroup>
+            </FlexController>
+            <FlexController contain={50} shrink={1}>
+              <InputGroup>
+                <FormLabel htmlFor="options-category">Category</FormLabel>
+                <Input
+                  type="text"
+                  placeholder="Overwrite category axis name"
+                  id="options-category"
+                  name="options-category"
+                  value={xAxisTitle}
+                  onChange={this.setXAxis}
+                />
+              </InputGroup>
+            </FlexController>
           </FlexContainer>
         )}
         {!isMap && !advanced && (

--- a/src/applications/widget-editor/src/styles-common/flex-controller.js
+++ b/src/applications/widget-editor/src/styles-common/flex-controller.js
@@ -1,24 +1,17 @@
 import styled, { css } from "styled-components";
 
 const FlexController = styled.div`
-  flex: 0 0 auto;
-  width: ${(props) =>
-    props.contain &&
-    css`
-      ${props.contain}%;
-    `}};
+  flex: ${props => props.grow || 0} ${props => props.shrink || 0} ${props => props.contain ? `${props.contain}%` : 'auto'}};
   display: flex;
-  box-sizing: border-box;
-  > * {
-    width: ${(props) =>
-      props.constrainElement ? `${props.constrainElement}%` : "100%"};
 
-    ${(props) =>
-      props.alignment &&
-      props.alignment === "right" &&
-      css`
-        margin-left: auto;
-      `}
+  > * {
+    ${(props) => props.constrainElement && css`
+      width: ${props.constrainElement}%;
+    `}
+
+    ${(props) => props.alignment && props.alignment === "right" && css`
+      margin-left: auto;
+    `}
   }
 `;
 

--- a/src/applications/widget-editor/src/styles-common/flex.js
+++ b/src/applications/widget-editor/src/styles-common/flex.js
@@ -8,10 +8,10 @@ const FlexContainer = styled.div`
   flex-flow: ${props => (props.row ? "row" : "column")};
   width: 100%;
 
-  ${props =>
-    props.row
-      ? `> * { padding-right: 20px; &:last-child { padding-right: 0; } } `
-      : ""}
+  ${props => props.row
+    ? `> * { margin-right: 20px; &:last-child { margin-right: 0; } }`
+    : ""
+  }
 
   label {
     flex-basis: 100%;


### PR DESCRIPTION
This PR is the continuation of #126. It focuses on the layout of the settings when the editor is smaller than 1060px (here tested with 925px, the size of the editor in RW's back-office).

A number of adjustments have been made such as the size of the inputs and the spacing between the tabs and the accordions.

## Testing instructions

You can force the editor to be smaller than 1060px and check whether the settings look good at that size.

## Pivotal Tracker

Not tracked.
