### PR TITLE
Prevent the user from updating a disabled select

### DIFF
--- a/src/packages/shared/src/components/select/style.js
+++ b/src/packages/shared/src/components/select/style.js
@@ -68,6 +68,7 @@ export default {
       border: `1px solid ${borderColor}`,
       borderRadius: "4px",
       backgroundColor: "rgba(255,255,255,1)",
+      pointerEvents: state.isDisabled ? 'none' : null,
     }
   },
 


### PR DESCRIPTION
This PR fixes a bug introduced in #124 where the user would be able to update the selected value of a disabled select.

## Testing instructions

1. Create a new filter (it can only be reproduced with new filters)
2. Select a column

The select will disable itself after a short period of time.

3. Click the select

The option list must not open.

## Pivotal Tracker

Not tracked.