### PR TITLE
Improve the usability of the selects in the settings by preventing scroll capture

### DIFF
--- a/src/packages/shared/src/components/select/component.js
+++ b/src/packages/shared/src/components/select/component.js
@@ -28,6 +28,7 @@ const Select = ({
       onChange={onChange}
       isDisabled={disabled}
       styles={styles || SelectStyles}
+      captureMenuScroll={false}
       components={{
         DropdownIndicator: () => <StyledDropdownIndicator />,
         ClearIndicator: props => <StyledCloseIndicator {...props} />,


### PR DESCRIPTION
This PR prevents `react-select` from capturing the scroll when the user reaches the top or the bottom of the options list. Essentially, this means that when the user is already at the bottom of the options list, if they scroll down again, the container will be scrolled.

Because the settings are in a scrollable container, if the scroll of the options list is captured, it is not propagated to the container, and the users are not able to see the full list of options. A few users have complained about this.

## Testing instructions

1. Create a new filter
2. Click the select to choose a column
3. Scroll down over the options list

If the options list is not entirely visible at the beginning, when you reach the end of the options list and keep scrolling down, the contained must be scrolled, allowing full visibility of the options.

## Pivotal Tracker

Not tracked.
