### PR TITLE
Fix a bug where no tab would be selected in the settings in some circumstances

### DIFF
--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react";
+import React, { Suspense, useMemo } from "react";
 import styled, { css } from "styled-components";
 
 import useDebounce from "hooks/use-debounce";
@@ -71,6 +71,13 @@ const EditorOptions = ({
   dataService,
   isMap,
 }) => {
+  const tabsVisibility = useMemo(() => ({
+    general: true,
+    map: isMap,
+    style: !isMap && !advanced,
+    advanced: disabledFeatures.indexOf("advanced-editor") === -1 && !isMap,
+    table: disabledFeatures.indexOf("table-view") === -1 && !isMap && !advanced,
+  }), [isMap, advanced, disabledFeatures]);
 
   const handleSliceCount = useDebounce((value) => {
     patchConfiguration({ sliceCount: parseInt(value) });
@@ -111,7 +118,7 @@ const EditorOptions = ({
 
   return (
     <StyledContainer compact={compact}>
-      <Tabs>
+      <Tabs visible={tabsVisibility}>
         <Tab id="general" label="General">
           <Accordion>
             <AccordionSection title="Description and labels" openDefault>
@@ -165,58 +172,50 @@ const EditorOptions = ({
           </Accordion>
         </Tab>
         
-        {isMap && (
-          <Tab id="map" label="Map">
-            <Accordion>
-              <AccordionSection title="Configuration" openDefault>
+        <Tab id="map" label="Map">
+          <Accordion>
+            <AccordionSection title="Configuration" openDefault>
+              <Suspense fallback={<div>Loading...</div>}>
+                <MapInfo />
+              </Suspense>
+            </AccordionSection>
+          </Accordion>
+        </Tab>
+
+        <Tab id="style" label="Visual style">
+          <Accordion>
+            {disabledFeatures.indexOf("typography") === -1 && (
+              <AccordionSection title="Typography">
                 <Suspense fallback={<div>Loading...</div>}>
-                  <MapInfo />
+                  <Typography />
                 </Suspense>
               </AccordionSection>
-            </Accordion>
-          </Tab>
-        )}
+            )}
 
-        {!isMap && !advanced && (
-          <Tab id="style" label="Visual style">
-            <Accordion>
-              {disabledFeatures.indexOf("typography") === -1 && (
-                <AccordionSection title="Typography">
-                  <Suspense fallback={<div>Loading...</div>}>
-                    <Typography />
-                  </Suspense>
-                </AccordionSection>
-              )}
+            {disabledFeatures.indexOf("theme-selection") === -1 && (
+              <AccordionSection
+                title="Color scheme"
+                openDefault={disabledFeatures.indexOf("typography") !== -1}
+              >
+                <Suspense fallback={<div>Loading...</div>}>
+                  <ColorSchemes />
+                </Suspense>
+              </AccordionSection>
+            )}
+          </Accordion>
+        </Tab>
 
-              {disabledFeatures.indexOf("theme-selection") === -1 && (
-                <AccordionSection
-                  title="Color scheme"
-                  openDefault={disabledFeatures.indexOf("typography") !== -1}
-                >
-                  <Suspense fallback={<div>Loading...</div>}>
-                    <ColorSchemes />
-                  </Suspense>
-                </AccordionSection>
-              )}
-            </Accordion>
-          </Tab>
-        )}
+        <Tab id="advanced" label="Advanced">
+          <Suspense fallback={<div>Loading...</div>}>
+            <AdvancedEditor />
+          </Suspense>
+        </Tab>
 
-        {disabledFeatures.indexOf("advanced-editor") === -1 && !isMap && (
-          <Tab id="advanced" label="Advanced">
-            <Suspense fallback={<div>Loading...</div>}>
-              <AdvancedEditor />
-            </Suspense>
-          </Tab>
-        )}
-
-        {disabledFeatures.indexOf("table-view") === -1 && !isMap && !advanced && (
-          <Tab id="table" label="Table view">
-            <Suspense fallback={<div>Loading...</div>}>
-              <TableView />
-            </Suspense>
-          </Tab>
-        )}
+        <Tab id="table" label="Table view">
+          <Suspense fallback={<div>Loading...</div>}>
+            <TableView />
+          </Suspense>
+        </Tab>
       </Tabs>
     </StyledContainer>
   );

--- a/src/applications/widget-editor/src/components/tabs/component.js
+++ b/src/applications/widget-editor/src/components/tabs/component.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { Button } from "@widget-editor/shared";
 import {
   StyledTabsContainer,
@@ -12,14 +12,25 @@ const TabButton = (props) => {
   return <Button style={{ height: "100%" }} {...props} />;
 };
 
-export const Tabs = ({ theme, children }) => {
-  const validChildren = useMemo(() => children.filter(c => !!c), [children]);
-  const [activeId, setActiveId] = useState(validChildren[0].props.id);
+export const Tabs = ({ visible, theme, children }) => {
+  const visibleChildren = useMemo(
+    () => children.filter(child => !!child && visible[child.props.id]),
+    [children, visible]
+  );
+  const [activeId, setActiveId] = useState(visibleChildren[0].props.id);
+
+  // When the user switched between map and chart, some tabs disappear
+  // Here we make sure that we always have a tab active
+  useEffect(() => {
+    if (!visible[activeId]) {
+      setActiveId(visibleChildren[0].props.id);
+    }
+  }, [visible, visibleChildren, activeId, setActiveId]);
 
   return (
     <StyledTabsContainer>
       <StyledList {...theme}>
-        {validChildren.map(({ props: { id, label } }) => label
+        {visibleChildren.map(({ props: { id, label } }) => label
           ? (
             <StyledListLabel key={id}>
               <TabButton onClick={() => setActiveId(id)} active={id === activeId}>
@@ -31,7 +42,7 @@ export const Tabs = ({ theme, children }) => {
         )}
       </StyledList>
       <StyledTabsContentBox {...theme}>
-        {validChildren.map(({ props: { id, children: content } }) => (
+        {visibleChildren.map(({ props: { id, children: content } }) => (
           <StyledTabsContent key={id} active={id === activeId}>
             {content}
           </StyledTabsContent>


### PR DESCRIPTION
This PR fixes an issue where no tab would be selected when the user would switch from map to chart (and vice versa) after selecting a tab that is not available for the other type of visualisation.

When this happens, we now put the focus back on the “General” tab.

## Testing instructions

For the test below, you can use the dataset `a86d906d-9862-4783-9e30-cdb68cd808b8`.

1. Select a chart visualisation (bars for example)
2. Click the “Visual style” tab
3. Change the visualisation type to map

The selected tab must be “General”.

4. Click the “Map” tab
5. Change the visualisation to a chart

The selected tab must also be “general”.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175262867).
