### PR TITLE
Fix bug causing value to be null and resets filter when filter operation changes

### DIFF
--- a/src/applications/widget-editor/src/components/filter/component.js
+++ b/src/applications/widget-editor/src/components/filter/component.js
@@ -50,9 +50,15 @@ const Filter = ({
         return filter;
       }
 
+      // If we change operation, keep old value from filter state
+      const keepValue = change.hasOwnProperty('operation');
+
       return {
         ...filter,
         ...change,
+        ...(keepValue && {
+          value: filter.value
+        }),
         config: !filter.column
           ? await FiltersService.fetchConfiguration(adapter, dataset, fields, change.column)
           : filter.config,

--- a/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -36,12 +36,12 @@ const FilterValue = ({ filter, onChange, ...rest }) => {
 
   const onChangeDebounced = useDebounce(onChange);
 
-  const onChangeValue = useCallback(({ target }) => {
-    let newValue = target.value;
+  const onChangeValue = useCallback((value) => {
+    let newValue = value;
     if (filter.type === 'number') {
-      newValue = +target.value;
+      newValue = +value;
     } else if (filter.type === 'date') {
-      newValue = new Date(target.value);
+      newValue = new Date(value);
     }
 
     setValue(getInputValue(filter.type, newValue));


### PR DESCRIPTION
Description of the PR

Issue when setting a filter and modifying operation, value gets unset. Now we simply check if the operation was changed and we keep the old filter value present. 

Before we pass filters to our SQL service we make sure they are valid. In this case value will be returned as NULL so the filter would basically be ignored until you modify value again. 

## Testing instructions

Instructions in pivotal task for this specific case, but this affects all filters tho when operation updates. Make sure when you have a filter set and modify operation that query updates and only changes operation but keeps value intact.

## Pivotal Tracker

https://www.pivotaltracker.com/story/show/175278835
https://www.pivotaltracker.com/story/show/175278891