### PR TITLE
Fix the layout of the compact mode

### DIFF
--- a/src/applications/widget-editor/src/components/editor/style.js
+++ b/src/applications/widget-editor/src/components/editor/style.js
@@ -25,14 +25,14 @@ export const StyleEditorContainer = styled.div`
 
 export const StyledRendererContainer = styled.div`
   flex-basis: 520px;
-  max-width: calc((100% - 20px) / 2);
+  max-width: ${props => props.isCompact || props.forceCompact ?'100%' : 'calc((100% - 20px) / 2)'};
   flex-shrink: 1;
   height: 100%;
 `;
 
 export const StyledOptionsContainer = styled.div`
-  flex-basis: calc((100% - 20px) / 2 + 20px);
-  max-width: calc((100% - 20px) / 2 + 20px);
+  flex-basis: ${props => props.isCompact || props.forceCompact ? '100%' : 'calc((100% - 20px) / 2 + 20px)'};
+  max-width: ${props => props.isCompact || props.forceCompact ? '100%' : 'calc((100% - 20px) / 2 + 20px)'};
   height: 100%;
 
   ${props => props.isCompact  || props.forceCompact


### PR DESCRIPTION
This PR fixes a bug where the layout of the compact mode would be very narrow due to using the layout of the full editor.

## Testing instructions

1. In the playground, force the compact mode

Make sure the editor is 520px wide.

2. Revert to the full editor

Make sure the total width is 1060px.

## Pivotal Tracker

Not tracked. Reported by Andrés when testing v2.4.0 on RW.
