### PR TITLE
Improve the layout of the chart and the legend

### DIFF
--- a/src/applications/renderer/src/components/chart/styles.js
+++ b/src/applications/renderer/src/components/chart/styles.js
@@ -22,10 +22,6 @@ export const StyledContainer = styled.div`
     height: auto;
   `}
 
-  ${(props) => props.compact && css`
-    padding-bottom: 50px;
-  `}
-
   .c-chart {
     display: flex;
     flex-direction: column;

--- a/src/applications/renderer/src/components/chart/styles.js
+++ b/src/applications/renderer/src/components/chart/styles.js
@@ -11,7 +11,6 @@ export const ChartNeedsOptions = styled.h4`
 export const StyledContainer = styled.div`
   ${(props) => !props.standalone && css`
     position: relative;
-    overflow: hidden;
     flex-grow: 1;
     flex-shrink: 1;
     width: 100%;
@@ -63,13 +62,5 @@ export const StyledContainer = styled.div`
         }
       }
     }
-
-    ${(props) => !props.standalone && css`
-      max-height: 400px;
-    `}
-
-    ${(props) => props.compact && css`
-      height: 400px;
-    `}
   }
 `;

--- a/src/applications/renderer/src/components/chart/styles.js
+++ b/src/applications/renderer/src/components/chart/styles.js
@@ -10,11 +10,13 @@ export const ChartNeedsOptions = styled.h4`
 
 export const StyledContainer = styled.div`
   ${(props) => !props.standalone && css`
-    position: relative;
     flex-grow: 1;
     flex-shrink: 1;
+    position: relative;
+    display: flex;
+    flex-direction: column;
     width: 100%;
-    padding: 15px 10px 55px ${props.hasYAxis ? '60px' : '20px'};
+    padding: 15px 10px 55px ${props.hasYAxis ? '60px' : '10px'};
   `}
 
   ${(props) => (props.standalone || props.thumbnail) && css`
@@ -23,10 +25,13 @@ export const StyledContainer = styled.div`
   `}
 
   .c-chart {
+    flex-basis: 0;
+    flex-grow: 1;
     display: flex;
     flex-direction: column;
     width: 100%;
     height: 100%;
+    overflow: hidden;
     background-position: 50%;
     background-size: cover;
 

--- a/src/applications/renderer/src/components/column-selections/style.js
+++ b/src/applications/renderer/src/components/column-selections/style.js
@@ -7,7 +7,7 @@ const SELECT_WIDTH = 250;
 export const StyledBottomSelect = styled.div`
   position: absolute;
   bottom: 5px;
-  left: ${props => props.hasYAxis ? 'calc((100% - 60px - 20px) / 2 + 60px)' : '50%'};
+  left: ${props => props.hasYAxis ? 'calc((100% - 60px - 10px) / 2 + 60px)' : '50%'};
   transform: translateX(-50%);
   width: ${SELECT_WIDTH}px;
 `;

--- a/src/applications/renderer/src/components/legend/component.js
+++ b/src/applications/renderer/src/components/legend/component.js
@@ -60,7 +60,7 @@ const Legend = ({
 
   return (
     <StyledContainer compact={compact}>
-      <StyledColorsBoxContainer overflowIsHidden={multipleItems} alignCenter={!multipleItems}>
+      <StyledColorsBoxContainer alignCenter={!multipleItems}>
           {!multipleItems && !advanced && (
             <StyledColorsBox alignCenter={false}>
               <StyledColorDot color={scheme.mainColor} />
@@ -68,7 +68,11 @@ const Legend = ({
             </StyledColorsBox>
           )}
           {multipleItems && widget.legend[0].values.map((item, index) => (
-            <StyledColorsBox alignCenter={true} key={`${item.label}-${index}`}>
+            <StyledColorsBox
+              title={resolveLabel(item.label, item.type) || '−'}
+              alignCenter={true}
+              key={`${item.label}-${index}`}
+            >
               <StyledColorDot color={item.value} />
               {resolveLabel(item.label, item.type) || '−'}
             </StyledColorsBox>

--- a/src/applications/renderer/src/components/legend/style.js
+++ b/src/applications/renderer/src/components/legend/style.js
@@ -3,27 +3,21 @@ import styled, { css } from "styled-components";
 import { SelectStyles as DefaultSelectStyles } from "@widget-editor/shared";
 
 export const StyledDropdownBox = styled.div`
-  flex-basis: 30%;
+  flex-basis: 40%;
   flex-shrink: 0;
   margin-left: 20px;
 `;
 
 export const StyledColorsBoxContainer = styled.div`
   flex-grow: 1;
+  display: flex;
+  flex-wrap: wrap;
+  max-height: 120px;
+  overflow-y: scroll;
 
-  ${(props) =>
-    props.alignCenter &&
-    css`
-      align-items: center;
-      display: flex;
-    `}
-
-  ${(props) =>
-    props.overflowIsHidden &&
-    css`
-      max-height: 70px;
-      overflow-y: scroll;
-    `}
+  ${(props) => props.alignCenter && css`
+    align-items: center;
+  `}
 `;
 
 export const StyledColorsBox = styled.div`
@@ -31,22 +25,27 @@ export const StyledColorsBox = styled.div`
   align-items: center;
   font-size: 14px;
   color: #717171;
-  ${(props) =>
-    props.alignCenter &&
-    css`
-      float: left;
-      width: 110px;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      margin: 5px;
-      padding-left: 20px;
-      position: relative;
-      > span {
-        position: absolute;
-        left: 0;
-      }
-    `}
+
+  ${(props) => props.alignCenter && css`
+    display: block;
+    position: relative;
+    flex-basis: calc(50% - (10px / 2));
+    margin: 5px 10px 5px 0;
+    padding-left: 20px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    &:nth-of-type(2n + 2) {
+      margin-right: 0;
+    }
+
+    > span {
+      position: absolute;
+      top: 1px;
+      left: 0;
+    }
+  `}
 `;
 
 export const StyledColorDot = styled.span`

--- a/src/applications/renderer/src/components/renderer/style.js
+++ b/src/applications/renderer/src/components/renderer/style.js
@@ -13,7 +13,7 @@ export const StyledContainer = styled.div`
 `;
 
 export const RestoringWidget = styled.div`
-  height: 300px;
+  flex-grow: 1;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
This PR improves the layout of the chart and the legend, as well as fixes layout issues with the compact mode specifically.

<p align="center">
<img width="560" alt="Legend can grow higher and the title on the items let the user see the whole text" src="https://user-images.githubusercontent.com/6073968/96852789-7acb9180-1451-11eb-8ce5-a7a2ecc76f8e.png">
</p>

Here's a breakdown of the changes:
- The X axis column select is not cut anymore at its top
- The X axis column select doesn't touch the chart anymore
- The column selects are now better aligned and center
- The legend now grows vertically up to 120px before having a scroll bar
- The legend is better displayed with more space for the legend items and more space for the colour select
- When the text of the legend items doesn't fit, it is shown with an ellipsis and a title has been added so the user can see the full text on hover
- When loading, the legend of the editor is now the correct size

## Testing instructions

You can test the changes with the widget `0948ea75-1eb2-42d2-89c2-f4dcff93b51c` (dataset: `acf42a1b-104b-4f81-acd0-549f805873fb`).

I would suggest testing the changes listed below, in “full” mode, compact mode, and making sure the standalone Renderer has no regression.

Overall, after this PR is merged, there should not be any layout issue anymore with the visualisation and the legend.

## Pivotal Tracker

- [Column select being cut off](https://www.pivotaltracker.com/story/show/175379147)
- [Wrong spacing between the column selects and the chart](https://www.pivotaltracker.com/story/show/175379113)
- [General legend improvements](https://www.pivotaltracker.com/story/show/175044962)
