### PR TITLE
Improve the layout of the settings tab

### DIFF
--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -74,7 +74,10 @@ const EditorOptions = ({
   const tabsVisibility = useMemo(() => ({
     general: true,
     map: isMap,
-    style: !isMap && !advanced,
+    style: !isMap && !advanced && (
+      disabledFeatures.indexOf("typography") === -1
+        || disabledFeatures.indexOf("theme-selection") === -1
+    ),
     advanced: disabledFeatures.indexOf("advanced-editor") === -1 && !isMap,
     table: disabledFeatures.indexOf("table-view") === -1 && !isMap && !advanced,
   }), [isMap, advanced, disabledFeatures]);

--- a/src/applications/widget-editor/src/components/tabs/style.js
+++ b/src/applications/widget-editor/src/components/tabs/style.js
@@ -42,7 +42,7 @@ export const StyledTabsContent = styled.div`
 
 export const StyledList = styled.ul`
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   padding: 20px 30px 10px 0;
   list-style: none;
 
@@ -52,11 +52,17 @@ export const StyledList = styled.ul`
 `;
 
 export const StyledListLabel = styled.li`
+  flex-grow: 1;
   color: red;
   margin: 0 5px 0 0;
 
   &:last-child {
     margin-right: 0;
+  }
+
+  button {
+    width: 100%;
+    text-align: center;
   }
 
   button[aria-pressed = "true"] {
@@ -66,5 +72,6 @@ export const StyledListLabel = styled.li`
   button[aria-pressed = "false"] {
     // Prevent the change from a 1px width to a 2px width to cause a jump
     margin: 0 1px;
+    width: calc(100% - 2px);
   }
 `;


### PR DESCRIPTION
This PR improves the settings tabs by:
- Hiding them if they are empty
- Making them fill the total horizontal space (design requirement)

## Testing instructions

1. Restore the widget `0948ea75-1eb2-42d2-89c2-f4dcff93b51c` (dataset: `acf42a1b-104b-4f81-acd0-549f805873fb`)
2. Switch to the “Map” visualisation

The two tabs, “General” and “Map”, must take half the horizontal space each.

3. Disable the `'theme-selection'` feature in the playground (file: `src/playground/widget-editor/src/components/editor/component.js`)

The “Style” tab must not be shown.

## Pivotal Tracker

- [Hide empty tabs](https://www.pivotaltracker.com/story/show/174984452)
- [Use all the available space](https://www.pivotaltracker.com/story/show/175044899)
