### PR TITLE
Improve the layout of the table

### DIFF
--- a/src/applications/widget-editor/src/components/accordion/style.js
+++ b/src/applications/widget-editor/src/components/accordion/style.js
@@ -5,7 +5,6 @@ import { AccordionArrowIcon } from "@widget-editor/shared"
 
 export const StyledAccordion = styled.div`
   width: 100%;
-  padding-bottom: 24px;
 `;
 
 export const StyledAccordionContent = styled.div`

--- a/src/applications/widget-editor/src/components/advanced-editor/style.js
+++ b/src/applications/widget-editor/src/components/advanced-editor/style.js
@@ -5,8 +5,6 @@ import { Button } from "@widget-editor/shared";
 import { StyledCallout } from "components/callout/style";
 
 export const Container = styled.div`
-  margin-top: 11px;
-
   label {
     margin-top: 20px;
   }

--- a/src/applications/widget-editor/src/components/table-view/style.js
+++ b/src/applications/widget-editor/src/components/table-view/style.js
@@ -2,38 +2,40 @@ import styled from "styled-components";
 
 export const StyledTableBox = styled.div`
   width: 100%;
-  margin: 11px 0 20px;
+  height: 100%;
   border: 1px solid rgba(26, 28, 34, 0.1);
+  background-color: #fff;
+  box-shadow: 0 1px 2px 0 rgba(0,0,0,0.09);
+  overflow: auto;
 `;
 
 export const StyledTable = styled.table`
-  border-collapse: collapse;
   width: 100%;
-  padding: 0;
-  border-radius: 4px;
-  overflow: hidden;
-  border: 1px solid rgba(26, 28, 34, 0.1);
-  font-size: 14px;
+  padding: 15px 30px;
+
+  // The two following properties are required to make the padding work
+  border-spacing: 0;
+  border-collapse: separate;
+
+  font-size: 16px;
+  color: #393f44;
+  text-align: left;
 `;
 
 export const StyledTr = styled.tr`
-  background-color: #fff;
-  border-bottom: 1px solid #d2d3d6;
-  box-sizing: border-box;
+  td {
+    // Because of border-collapse (see StyledTable) the border needs to be applied to the td
+    border-bottom: 1px solid rgba(210, 211, 214, 0.5)
+  }
 `;
 
 export const StyledTd = styled.td`
-  width: 100%;
-  padding: 11px 20px;
-  font-size: 15px;
-  color: #393f44;
+  padding: 7px 20px 7px 0;
 `;
 
-export const StyledTh = styled.td`
-  position: relative;
-  font-size: 16px;
-  color: #393f44;
+export const StyledTh = styled.th`
+  padding: 7px 0;
   font-weight: 700;
   white-space: nowrap;
-  padding: 11px 20px;
+  border-bottom: 1px solid #d2d3d6;
 `;

--- a/src/applications/widget-editor/src/components/tabs/style.js
+++ b/src/applications/widget-editor/src/components/tabs/style.js
@@ -1,20 +1,20 @@
 import styled, { css } from 'styled-components';
 
 export const StyledTabsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
   position: relative;
   height: 100%;
 `;
 
 export const StyledTabsContentBox = styled.div`
+  flex-grow: 1;
+  padding: 10px 30px 0 0;
   overflow-y: auto;
-  height: calc(100% - 80px);
-  padding-right: 30px;
 
   ${(props) => (props.compact.isCompact || props.compact.forceCompact) && css`
-    height: calc(100% - 65px);
-    padding: 0 10px;
+    padding: 10px;
   `}
-
 
   ::-webkit-scrollbar {
     width: 7px;
@@ -38,6 +38,20 @@ export const StyledTabsContentBox = styled.div`
 
 export const StyledTabsContent = styled.div`
   display: ${props => props.active ? 'block' : 'none'};
+
+  // This property is only useful for the table view where the children is 100% the height of this
+  // div
+  // The 20px comes from the :after pseudo-element
+  height: calc(100% - 20px);
+
+  // Used for the bottom padding
+  // The padding-bottom of StyledTabsContentBox doesn't work with overflow-y: auto
+  &:after {
+    display: block;
+    width: 100%;
+    height: 20px;
+    content: '';
+  }
 `;
 
 export const StyledList = styled.ul`


### PR DESCRIPTION
This PR improves the layout of the table by:
- Updating the styles to match the design
- Making the table overflow in both directions (the column headers don't wrap)

<p align="center">
<img width="598" alt="The styles of the tables have been updated and it now overflows in both directions" src="https://user-images.githubusercontent.com/6073968/96994360-86d45380-1524-11eb-834f-928b9d4ee232.png">
</p>

## Testing instructions

I've been testing with the widget `22c38a5b-963c-43ca-8d5a-18a17a929028` (dataset: `f655d9b2-ea32-4753-9556-182fc6d3156b`).

Make sure that in compact mode, and if the widget-editor is narrower than 1060px (for example 925px), the table overflows in both directions.

Make sure the other settings tabs look great has their container styles have been updated.

## Pivotal Tracker

- [Overflow issues](https://www.pivotaltracker.com/story/show/172823264)
- [Match the design](https://www.pivotaltracker.com/story/show/175044688)
