### PR TITLE
Fix wrong serialisation of widgets with date columns

### DIFF
--- a/src/packages/shared/src/modules/widget-config/selectors.js
+++ b/src/packages/shared/src/modules/widget-config/selectors.js
@@ -25,6 +25,9 @@ export const selectSerializedWidgetConfig = createSelector(
             name: 'table',
             transform: data.transform ?? null,
             format: {
+              // The format property may contain instructions such as parse that tells Vega to parse
+              // a column as a date
+              ...(data.format ?? {}),
               type: 'json',
               property: 'data',
             },


### PR DESCRIPTION
This PR fixes a bug where widgets built with a date column wouldn't be serialised correctly. When rendered, the Vega runtime wouldn't be able to display them correctly.

The issue is located in a piece of code where the embedded widget data is replaced by its URL (in order to be saved in the API). That code would replace any property in a Vega `format` object which is responsible for telling Vega how to parse the columns (here as a date).

## Testing instructions

1. Restore the widget `22c38a5b-963c-43ca-8d5a-18a17a929028` (dataset: `f655d9b2-ea32-4753-9556-182fc6d3156b`)
2. Click the “Get editor state” button of the playground

Look at the object `payload.widgetConfig.data[0].format`. It must contain the property `parse` with the value `{ x: 'date' }`.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175396516).
