### PR TITLE
Bugfix/state-proxy

### DIFF
--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -140,7 +140,6 @@ function* syncEditor() {
 
 function* handleRestore() {
   yield call(initializeData);
-
   const { widgetEditor } = yield select();
   const { editor } = widgetEditor;
   const { widget } = editor;

--- a/src/packages/core/__tests__/state-proxy/helpers.ts
+++ b/src/packages/core/__tests__/state-proxy/helpers.ts
@@ -2,9 +2,11 @@ import StateProxy from '../../src/services/state-proxy';
 
 import { BASE_STATE } from './mock';
 
-export const genInstance = () => {
+export const genInstance = (conf = null) => {
   const instance = new StateProxy();
-  instance.update(BASE_STATE);
+  if (!conf || !conf.empty) {
+    instance.update(BASE_STATE);
+  }
   return instance;
 }
 

--- a/src/packages/core/__tests__/state-proxy/state-proxy.test.ts
+++ b/src/packages/core/__tests__/state-proxy/state-proxy.test.ts
@@ -12,9 +12,9 @@ describe('State proxy tests', () => {
 
   test('If previous instance is empty we should exit state proxy', () => {
     const instance = genInstance({ empty: true });
-    let patch = patchConfiguration({ limit: 100 });
-    let shouldUpdateData = instance.ShouldUpdateData(patch);
-    let shouldUpdateVega = instance.ShouldUpdateData(patch);
+    const patch = patchConfiguration({ limit: 100 });
+    const shouldUpdateData = instance.ShouldUpdateData(patch);
+    const shouldUpdateVega = instance.ShouldUpdateData(patch);
     expect(shouldUpdateData).toBe(false);
     expect(shouldUpdateData).toBe(false);
   });

--- a/src/packages/core/__tests__/state-proxy/state-proxy.test.ts
+++ b/src/packages/core/__tests__/state-proxy/state-proxy.test.ts
@@ -10,6 +10,15 @@ describe('State proxy tests', () => {
     expect(instance.forceVegaUpdate).toBe(false);
   });
 
+  test('If previous instance is empty we should exit state proxy', () => {
+    const instance = genInstance({ empty: true });
+    let patch = patchConfiguration({ limit: 100 });
+    let shouldUpdateData = instance.ShouldUpdateData(patch);
+    let shouldUpdateVega = instance.ShouldUpdateData(patch);
+    expect(shouldUpdateData).toBe(false);
+    expect(shouldUpdateData).toBe(false);
+  });
+
   test("State proxy should update data and force vega update", () => {
     const instance = genInstance();
     let patch = patchConfiguration({ limit: 100 });

--- a/src/packages/core/src/services/state-proxy.ts
+++ b/src/packages/core/src/services/state-proxy.ts
@@ -33,7 +33,7 @@ export default class StateProxy {
    * In a few cases we need to force vega to update, as these properties are already
    * applied to the local state when checking @ShouldUpdateVega
    * @propsForceVegaUpdate
-   * 1. Any column: value,category,color
+   * 1. Any column: value, category, color
    * 2. When limit changes in the UI
    * 3. When aggregateFunction changes in the UI
    * @param state
@@ -58,6 +58,9 @@ export default class StateProxy {
   ShouldUpdateData(state: any) {
     const { prev, next } = this.getStateDiff(state);
     let shouldUpdate = false;
+
+    // If we don't have a previous state present, simply exit as another one is incoming
+    if (!prev) return false;
 
     // If limit changes, we need to fetch new data
     shouldUpdate = prev.configuration.limit !== next.configuration.limit;
@@ -91,6 +94,9 @@ export default class StateProxy {
     if (this.forceVegaUpdate) {
       return true;
     }
+
+    // If we don't have a previous state present, simply exit as another one is incoming
+    if (!prev) return false;
 
     let shouldUpdate = false;
 


### PR DESCRIPTION
Description of the PR

Fixes a bug when initializing the editor with a map. As map can be done before data we need to make sure to check for previous configuration existence. in our case we will simply exit when no previous configuration is set. think of it as a debounce as we want these calls to only be done once on initialization. 

## Testing instructions

test with this one and it should not crash http://api.resourcewatch.org/widget/a85f1ea4-4344-463a-94d5-bb3b4ae91dab

## Pivotal Tracker

none
