### PR TITLE
Fix bugs with the filters

### DIFF
--- a/src/applications/widget-editor/src/components/filter/component.js
+++ b/src/applications/widget-editor/src/components/filter/component.js
@@ -50,15 +50,9 @@ const Filter = ({
         return filter;
       }
 
-      // If we change operation, keep old value from filter state
-      const keepValue = change.hasOwnProperty('operation');
-
       return {
         ...filter,
         ...change,
-        ...(keepValue && {
-          value: filter.value
-        }),
         config: !filter.column
           ? await FiltersService.fetchConfiguration(adapter, dataset, fields, change.column)
           : filter.config,

--- a/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import styled from "styled-components";
 import PropTypes from 'prop-types';
 
@@ -47,6 +47,13 @@ const FilterValue = ({ filter, onChange, ...rest }) => {
     setValue(getInputValue(filter.type, newValue));
     onChangeDebounced(newValue);
   }, [filter, onChangeDebounced]);
+
+  // When the filter changes, we make sure to update the UI as well
+  // This case occurs when the user changes the filter's operation: the value is set to null so we
+  // need to make sure the input is also empty
+  useEffect(() => {
+    setValue(getInputValue(filter.type, filter.value));
+  }, [filter, setValue]);
 
   return (
     <StyledInput

--- a/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -36,12 +36,12 @@ const FilterValue = ({ filter, onChange, ...rest }) => {
 
   const onChangeDebounced = useDebounce(onChange);
 
-  const onChangeValue = useCallback((value) => {
-    let newValue = value;
+  const onChangeValue = useCallback(({ target }) => {
+    let newValue = target.value;
     if (filter.type === 'number') {
-      newValue = +value;
+      newValue = +target.value;
     } else if (filter.type === 'date') {
-      newValue = new Date(value);
+      newValue = new Date(target.value);
     }
 
     setValue(getInputValue(filter.type, newValue));

--- a/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -74,7 +74,7 @@ const FilterValue = ({ filter, onChange, ...rest }) => {
         }
         : {}
       )}
-      value={value}
+      value={`${value}`}
       onChange={onChangeValue}
       {...rest}
     />

--- a/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -36,12 +36,12 @@ const FilterValue = ({ filter, onChange, ...rest }) => {
 
   const onChangeDebounced = useDebounce(onChange);
 
-  const onChangeValue = useCallback(({ target }) => {
-    let newValue = target.value;
+  const onChangeValue = useCallback((value) => {
+    let newValue = value;
     if (filter.type === 'number') {
-      newValue = +target.value;
+      newValue = +value;
     } else if (filter.type === 'date') {
-      newValue = new Date(target.value);
+      newValue = new Date(value);
     }
 
     setValue(getInputValue(filter.type, newValue));

--- a/src/applications/widget-editor/src/hooks/use-debounce.js
+++ b/src/applications/widget-editor/src/hooks/use-debounce.js
@@ -4,7 +4,7 @@ import debounce from 'lodash/debounce';
 function useDebounce(callback, wait = 300) {
   const debouncedCallback = useCallback(
     debounce((...args) => callback(...args), wait),
-    [wait],
+    [wait, callback],
   );
 
   return debouncedCallback;


### PR DESCRIPTION
This PR fixes 3 bugs related to the filters:
- #132 fixed an issue where the filter UI would display stale data (creating confusion for the user) but created another: switching between operations could crash the editor. This code change adds a `useEffect` hook which ensures the UI display the correct data.
- #119 standardised the debounce's wait times by introducing a `useDebounce` hook, but the callback would not be changed if `useDebounce` would receive a new one. When the user would switch between operations and change their value, the operation would revert back to its previous value unexpectedly. The proposed change include the callback as the dependency of the `useDebounce`'s internal `useCallback`.
- #125 standardised the `Input` component and requires that its `value` prop must be a string, but the filters input would sometimes send numbers, which would display a prop type error in the console. This PR ensures strings are sent to the `Input` component.

## Testing instructions

**First bug fix**:
1. Restore the dataset `ac6dcdb3-2beb-4c66-9f83-565c16c2c914`
2. Create a bar chart with “Time Period” on the X axis, “Food Insecurity Status” on the Y axis, “Food Insecurity Status” in the colour field and a “Count” aggregation
3. Set a filter so “Food Insecurity Status” is “Greater than” 3

Make sure the widget is updated.

4. Change the filter's operation to “Less than”

Make sure the filter's value field is emptied and that the data is not filtered anymore.

**Second bug fix**:
1. Restore the dataset `ac6dcdb3-2beb-4c66-9f83-565c16c2c914`
2. Create a bar chart with “Time Period” on the X axis, “Food Insecurity Status” on the Y axis, “Food Insecurity Status” in the colour field and a “Count” aggregation
3. Set a filter so “Food Insecurity Status” is “Greater than” 3

Make sure the widget is updated.

4. Change the filter's operation to “Less than”
5. Set the filter's value to 2

Make sure the operation is still “Less than” and that the filter is correctly applied (look at the legend).

**Third bug fix**:
Repeat the previous test, make sure no prop type error is displayed in the console.

## Pivotal Tracker

Not tracked.
