### PR TITLE
Prevent a crash that occurs when emptying the value of a date filter

### DIFF
--- a/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
+++ b/src/applications/widget-editor/src/components/filter/components/FilterValue/component.js
@@ -36,17 +36,24 @@ const FilterValue = ({ filter, onChange, ...rest }) => {
 
   const onChangeDebounced = useDebounce(onChange);
 
-  const onChangeValue = useCallback((value) => {
-    let newValue = value;
+  const onChangeValue = useCallback((rawValue) => {
+    let newValue = rawValue;
     if (filter.type === 'number') {
-      newValue = +value;
+      newValue = +rawValue;
     } else if (filter.type === 'date') {
-      newValue = new Date(value);
+      newValue = new Date(rawValue);
+
+      // If the user empties the input we just keep the previous value
+      // We can't easily save the filter as null for dates
+      // If the user wants to remove the filter, they can do so instead of removing the value
+      if (isNaN(+newValue)) {
+        newValue = new Date(value);
+      }
     }
 
     setValue(getInputValue(filter.type, newValue));
     onChangeDebounced(newValue);
-  }, [filter, onChangeDebounced]);
+  }, [value, filter, onChangeDebounced]);
 
   // When the filter changes, we make sure to update the UI as well
   // This case occurs when the user changes the filter's operation: the value is set to null so we


### PR DESCRIPTION
This PR prevents a crash that occurs when the user empties the value of a date filter.

The changes don't completely solve the issue, but rather avoid it: when the user tries to empty the value, it keeps its value. If we were to set the filter's value to `null`, we would need deeper changes to several part of the code such as the serialisation of the filter. If the user wants to get rid of the filter, they can do so.

This is specific to the date inputs: number inputs, for example, can't be emptied (their default value is 0).

## Testing instructions

1. Add `return Promise.resolve({ min: 1601669722231, max: 1602669722231 });` to the `getColumnMinAndMax` function of the Fields service
2. Restore the dataset `852f2275-91a8-4500-9f10-89880dc53f22`
3. Create a simple chart
4. Add a filter using the “year_date” column, with the “Between” operation
5. Click the “empty” button of one of the inputs (this is a native button)

Make sure the editor doesn't crash.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175264660).
