### PR TITLE
Only display the relevant fields in the editor

### DIFF
--- a/src/packages/types/src/dataset.ts
+++ b/src/packages/types/src/dataset.ts
@@ -14,6 +14,7 @@ export interface Payload {
     tableName: string;
     metadata: any;
     widget: Widget.Payload[] | null;
+    widgetRelevantProps: string[];
   };
   id: Id;
 }


### PR DESCRIPTION
This PR filters out the fields that aren't marked as relevant from the editor. If the dataset doesn't have any relevant fields, then all of them are permitted.

## Testing instructions

1. Restore the dataset `bced4001-425a-4fad-8c22-8214d9340ea4`
2. Click on any select that contains fields

Make sure the only available options are “Country”, “Year” and “Percentage of Energy Consumption from Renewable Sources (%)”.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175349808).
