### PR TITLE
Make the table view smarter

### DIFF
--- a/src/applications/renderer/src/components/legend/component.js
+++ b/src/applications/renderer/src/components/legend/component.js
@@ -2,7 +2,6 @@ import React, { useCallback } from "react";
 
 import { utils } from '@widget-editor/core';
 import { Select } from "@widget-editor/shared";
-import AGGREGATION_OPTIONS from "@widget-editor/shared/lib/constants/aggregations";
 
 import {
   StyledContainer,
@@ -12,8 +11,6 @@ import {
   StyledDropdownBox,
   SelectStyles,
 } from "./style";
-
-import { formatOptionLabel } from './utils';
 
 // XXX: Move me
 function resolveLabel(label, type) {
@@ -31,16 +28,11 @@ const Legend = ({
   scheme,
   selectedColumn,
   columns,
-  aggregateFunction,
-  valueColumn,
   patchConfiguration,
   compact,
 }) => {
   const isPie = configuration.chartType === "pie";
   const multipleItems = widget?.legend?.[0]?.values.length > 0;
-  const aggregation = aggregateFunction
-    ? AGGREGATION_OPTIONS.find(o => o.value === aggregateFunction)?.label
-    : null;
 
   const handleChange = useCallback((option) => {
     const newOption = option.value === "_single_color"
@@ -85,10 +77,6 @@ const Legend = ({
             value={selectedColumn}
             options={columns}
             onChange={handleChange}
-            formatOptionLabel={(...props) => formatOptionLabel(
-              // The aggregation is only applied to the value column
-              valueColumn?.name === selectedColumn?.value ? aggregation : null, ...props
-            )}
             styles={SelectStyles}
           />
         </StyledDropdownBox>

--- a/src/applications/renderer/src/components/legend/index.js
+++ b/src/applications/renderer/src/components/legend/index.js
@@ -3,8 +3,6 @@ import { redux } from "@widget-editor/shared";
 import { patchConfiguration,  } from "@widget-editor/shared/lib/modules/configuration/actions";
 import {
   selectSelectedColorOption,
-  selectAggregateFunction,
-  selectValue,
 } from "@widget-editor/shared/lib/modules/configuration/selectors";
 import { selectColumnOptions } from "@widget-editor/shared/lib/modules/editor/selectors";
 import * as themeSelectors from "@widget-editor/shared/lib/modules/theme/selectors";
@@ -19,8 +17,6 @@ export default redux.connectState(
     widget: state.widgetConfig,
     configuration: state.configuration,
     selectedColumn: selectSelectedColorOption(state),
-    aggregateFunction: selectAggregateFunction(state),
-    valueColumn: selectValue(state),
     columns: [
       {
         label: "Single color",

--- a/src/applications/widget-editor/src/components/table-view/component.js
+++ b/src/applications/widget-editor/src/components/table-view/component.js
@@ -30,7 +30,17 @@ const getTypeIcon = (type) => {
   return Icon;
 }
 
-const TableView = ({ widgetData, value, category, color, aggregateFunction }) => {
+const TableView = ({
+  widgetData,
+  tableData,
+  columnOptions,
+  value,
+  category,
+  color,
+  aggregateFunction
+}) => {
+  const showFullTable = useMemo(() => !category || !value, [value, category]);
+
   const aggregation = useMemo(() => aggregateFunction
     ? AGGREGATION_OPTIONS.find(o => o.value === aggregateFunction)?.label
     : null,
@@ -38,6 +48,19 @@ const TableView = ({ widgetData, value, category, color, aggregateFunction }) =>
 
   // These are the colunms we want to show in the table
   const relevantColumns = useMemo(() => {
+    // If the user has not set the colunms required to build a chart, we want to show a full table
+    if (showFullTable) {
+      const columns = columnOptions.reduce((res, option) => ({
+        ...res,
+        [option.value]: {
+          name: option.label,
+          Icon: getTypeIcon(option.type),
+        },
+      }), {});
+
+      return columns;
+    }
+
     const columns = {
       x: category ? { ...category, Icon: getTypeIcon(category.type) } : null,
       y: value ? { ...value, Icon: getTypeIcon(value.type), aggregation } : null,
@@ -66,7 +89,7 @@ const TableView = ({ widgetData, value, category, color, aggregateFunction }) =>
     }
 
     return columns;
-  }, [category, value, color, aggregation]);
+  }, [category, value, color, aggregation, showFullTable, columnOptions]);
 
   return (
     <StyledTableBox>
@@ -90,7 +113,7 @@ const TableView = ({ widgetData, value, category, color, aggregateFunction }) =>
           </StyledTr>
         </thead>
         <tbody>
-          {widgetData.map((row, index) => (
+          {(showFullTable ? tableData : widgetData).map((row, index) => (
             <StyledTr key={index}>
               {Object.keys(relevantColumns).map(
                 column => <StyledTd key={column}>{row[column]}</StyledTd>
@@ -111,6 +134,8 @@ const ColumnType = PropTypes.shape({
 
 TableView.propTypes = {
   widgetData: PropTypes.array.isRequired,
+  tableData: PropTypes.array.isRequired,
+  columnOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   value: ColumnType,
   category: ColumnType,
   color: ColumnType,

--- a/src/applications/widget-editor/src/components/table-view/component.js
+++ b/src/applications/widget-editor/src/components/table-view/component.js
@@ -1,8 +1,7 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 
-import { CategoryIcon, NumberIcon, DateIcon, UnknownIcon } from '@widget-editor/shared';
-import AGGREGATION_OPTIONS from "@widget-editor/shared/lib/constants/aggregations";
+import { showFullTable, getAggregationName, getRelevantColumns } from "./helpers";
 import {
   StyledTableBox,
   StyledTable,
@@ -10,25 +9,6 @@ import {
   StyledTh,
   StyledTd,
 } from "./style";
-
-const getTypeIcon = (type) => {
-  let Icon;
-  switch (type) {
-    case 'string':
-      Icon = CategoryIcon;
-      break;
-    case 'number':
-      Icon = NumberIcon;
-      break;
-    case 'date':
-      Icon = DateIcon;
-      break;
-    default:
-      Icon = UnknownIcon;
-  }
-
-  return Icon;
-}
 
 const TableView = ({
   widgetData,
@@ -39,57 +19,14 @@ const TableView = ({
   color,
   aggregateFunction
 }) => {
-  const showFullTable = useMemo(() => !category || !value, [value, category]);
-
-  const aggregation = useMemo(() => aggregateFunction
-    ? AGGREGATION_OPTIONS.find(o => o.value === aggregateFunction)?.label
-    : null,
-  [aggregateFunction]);
+  const fullTable = useMemo(() => showFullTable(category, value), [value, category]);
+  const aggregation = useMemo(() => getAggregationName(aggregateFunction), [aggregateFunction]);
 
   // These are the colunms we want to show in the table
-  const relevantColumns = useMemo(() => {
-    // If the user has not set the colunms required to build a chart, we want to show a full table
-    if (showFullTable) {
-      const columns = columnOptions.reduce((res, option) => ({
-        ...res,
-        [option.value]: {
-          name: option.label,
-          Icon: getTypeIcon(option.type),
-        },
-      }), {});
-
-      return columns;
-    }
-
-    const columns = {
-      x: category ? { ...category, Icon: getTypeIcon(category.type) } : null,
-      y: value ? { ...value, Icon: getTypeIcon(value.type), aggregation } : null,
-      color: color ? { ...color, Icon: getTypeIcon(color.type) } : null,
-    };
-
-    // We remove the columns that are not set by the user
-    Object.keys(columns).forEach(key => {
-      if (!columns[key]) {
-        delete columns[key];
-      }
-    });
-
-    // If the user has chosen the same column for the X and Y axis, and there is not an aggregation,
-    // we avoid displaying the column twice in the table
-    if (columns.x?.name && columns.x?.name === columns.y?.name && !aggregation) {
-      delete columns.y;
-    }
-
-    // If the user has chosen the same column for the X axis and color, or the user has chosen the
-    // same column for the Y axis and color and there is not an aggregation, we also remove the
-    // color column to avoid displaying it twice in the table
-    if ((columns.x?.name && columns.x?.name === columns.color?.name)
-      || (columns.y?.name && columns.y?.name === columns.color?.name && !aggregation)) {
-      delete columns.color;
-    }
-
-    return columns;
-  }, [category, value, color, aggregation, showFullTable, columnOptions]);
+  const relevantColumns = useMemo(
+    () => getRelevantColumns(category, value, color, aggregation, columnOptions),
+    [category, value, color, aggregation, columnOptions]
+  );
 
   return (
     <StyledTableBox>
@@ -113,7 +50,7 @@ const TableView = ({
           </StyledTr>
         </thead>
         <tbody>
-          {(showFullTable ? tableData : widgetData).map((row, index) => (
+          {(fullTable ? tableData : widgetData).map((row, index) => (
             <StyledTr key={index}>
               {Object.keys(relevantColumns).map(
                 column => <StyledTd key={column}>{row[column]}</StyledTd>

--- a/src/applications/widget-editor/src/components/table-view/component.js
+++ b/src/applications/widget-editor/src/components/table-view/component.js
@@ -92,9 +92,9 @@ const TableView = ({ widgetData, value, category, color, aggregateFunction }) =>
         <tbody>
           {widgetData.map((row, index) => (
             <StyledTr key={index}>
-              <StyledTd>{row.x}</StyledTd>
-              <StyledTd>{row.y}</StyledTd>
-              {!!row.color && <StyledTd>{row.color}</StyledTd>}
+              {Object.keys(relevantColumns).map(
+                column => <StyledTd key={column}>{row[column]}</StyledTd>
+              )}
             </StyledTr>
           ))}
         </tbody>

--- a/src/applications/widget-editor/src/components/table-view/component.js
+++ b/src/applications/widget-editor/src/components/table-view/component.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
 
 import {
   StyledTableBox,
@@ -8,31 +9,59 @@ import {
   StyledTd,
 } from "./style";
 
-const TableView = ({ widgetData, configuration }) => {
-  const value = configuration?.value?.alias || configuration?.value?.name || "";
-  const category = configuration?.category?.alias || configuration?.category?.name || "";
+const TableView = ({ widgetData, value, category, color, aggregateFunction }) => {
+  const columns = useMemo(() => (
+    [category, value, color]
+      .filter(column => !!column)
+      .map(column => [column.name, column.alias || column.name])
+      .reduce((res, column) => ({ ...res, [column[0]]: column[1] }), {})
+  ), [value, category, color]);
 
   return (
     <StyledTableBox>
       <StyledTable>
         <thead>
           <StyledTr>
-            <StyledTh>{category}</StyledTh>
-            <StyledTh>{value}</StyledTh>
+            {
+              Object.keys(columns).map(
+                column => <StyledTh key={column}>{columns[column]}</StyledTh>
+              )
+            }
           </StyledTr>
         </thead>
         <tbody>
-          {widgetData &&
-            widgetData.map((el, key) => (
-              <StyledTr key={key}>
-                <StyledTd>{el.x}</StyledTd>
-                <StyledTd center>{el.y}</StyledTd>
-              </StyledTr>
-            ))}
+          {widgetData.map((row, index) => (
+            <StyledTr key={index}>
+              <StyledTd>{row.x}</StyledTd>
+              <StyledTd>{row.y}</StyledTd>
+              {!!row.color && <StyledTd>{row.color}</StyledTd>}
+            </StyledTr>
+          ))}
         </tbody>
       </StyledTable>
     </StyledTableBox>
   );
+};
+
+const ColumnType = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  alias: PropTypes.string
+});
+
+TableView.propTypes = {
+  widgetData: PropTypes.array.isRequired,
+  value: ColumnType,
+  category: ColumnType,
+  color: ColumnType,
+  aggregateFunction: PropTypes.string,
+};
+
+TableView.defaultProps = {
+  value: null,
+  category: null,
+  color: null,
+  aggregateFunction: null,
 };
 
 export default TableView;

--- a/src/applications/widget-editor/src/components/table-view/component.js
+++ b/src/applications/widget-editor/src/components/table-view/component.js
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 
+import { CategoryIcon, NumberIcon, DateIcon, UnknownIcon } from '@widget-editor/shared';
 import {
   StyledTableBox,
   StyledTable,
@@ -13,8 +14,30 @@ const TableView = ({ widgetData, value, category, color, aggregateFunction }) =>
   const columns = useMemo(() => (
     [category, value, color]
       .filter(column => !!column)
-      .map(column => [column.name, column.alias || column.name])
-      .reduce((res, column) => ({ ...res, [column[0]]: column[1] }), {})
+      .reduce((res, column) => {
+        let Icon;
+        switch (column.type) {
+          case 'string':
+            Icon = CategoryIcon;
+            break;
+          case 'number':
+            Icon = NumberIcon;
+            break;
+          case 'date':
+            Icon = DateIcon;
+            break;
+          default:
+            Icon = UnknownIcon;
+        }
+
+        return {
+          ...res,
+          [column.name]: {
+            name: column.alias || column.name,
+            Icon,
+          }
+        };
+      }, {})
   ), [value, category, color]);
 
   return (
@@ -22,11 +45,15 @@ const TableView = ({ widgetData, value, category, color, aggregateFunction }) =>
       <StyledTable>
         <thead>
           <StyledTr>
-            {
-              Object.keys(columns).map(
-                column => <StyledTh key={column}>{columns[column]}</StyledTh>
-              )
-            }
+            {Object.keys(columns).map(column => {
+              const Icon = columns[column].Icon;
+              
+              return (
+                <StyledTh key={column}>
+                  <Icon /> {columns[column].name}
+                </StyledTh>
+              );
+            })}
           </StyledTr>
         </thead>
         <tbody>

--- a/src/applications/widget-editor/src/components/table-view/helpers.js
+++ b/src/applications/widget-editor/src/components/table-view/helpers.js
@@ -1,0 +1,86 @@
+import { CategoryIcon, NumberIcon, DateIcon, UnknownIcon } from '@widget-editor/shared';
+import AGGREGATION_OPTIONS from "@widget-editor/shared/lib/constants/aggregations";
+
+/**
+ * Return the type icon component
+ * @param {string} type Type of the column
+ */
+const getTypeIcon = (type) => {
+  let Icon;
+  switch (type) {
+    case 'string':
+      Icon = CategoryIcon;
+      break;
+    case 'number':
+      Icon = NumberIcon;
+      break;
+    case 'date':
+      Icon = DateIcon;
+      break;
+    default:
+      Icon = UnknownIcon;
+  }
+
+  return Icon;
+};
+
+/**
+ * Whether to show the full table or the widget's data
+ */
+export const showFullTable = (category, value) => !category || !value;
+
+/**
+ * Return the display name of the aggregate function
+ * @param {string} aggregateFunction Aggregation function
+ */
+export const getAggregationName = (aggregateFunction) => aggregateFunction
+  ? AGGREGATION_OPTIONS.find(o => o.value === aggregateFunction)?.label
+  : null;
+
+/**
+ * Return the list of relevant columns
+ * @returns {{ [column: string]: { name: string, alias?: string, Icon: React.Component, aggregation?: boolean }}}
+ */
+export const getRelevantColumns = (category, value, color, aggregation, columnOptions) => {
+  // If the user has not set the colunms required to build a chart, we want to show a full table
+  if (showFullTable(category, value)) {
+    const columns = columnOptions.reduce((res, option) => ({
+      ...res,
+      [option.value]: {
+        name: option.label,
+        Icon: getTypeIcon(option.type),
+      },
+    }), {});
+
+    return columns;
+  }
+
+  const columns = {
+    x: category ? { ...category, Icon: getTypeIcon(category.type) } : null,
+    y: value ? { ...value, Icon: getTypeIcon(value.type), aggregation } : null,
+    color: color ? { ...color, Icon: getTypeIcon(color.type) } : null,
+  };
+
+  // We remove the columns that are not set by the user
+  Object.keys(columns).forEach(key => {
+    if (!columns[key]) {
+      delete columns[key];
+    }
+  });
+
+  // If the user has chosen the same column for the X and Y axis, and there is not an aggregation,
+  // we avoid displaying the column twice in the table
+  if (columns.x?.name && columns.x?.name === columns.y?.name && !aggregation) {
+    delete columns.y;
+  }
+
+  // If the user has chosen the same column for the X axis and color, or the user has chosen the
+  // same column for the Y axis and color and there is not an aggregation, we also remove the
+  // color column to avoid displaying it twice in the table
+  if ((columns.x?.name && columns.x?.name === columns.color?.name)
+    || (columns.y?.name && columns.y?.name === columns.color?.name && !aggregation)) {
+    delete columns.color;
+  }
+
+  return columns;
+};

--- a/src/applications/widget-editor/src/components/table-view/index.js
+++ b/src/applications/widget-editor/src/components/table-view/index.js
@@ -1,8 +1,18 @@
 import { connectState } from "@widget-editor/shared/lib/helpers/redux";
+import { selectWidgetData } from "@widget-editor/shared/lib/modules/editor/selectors";
+import {
+  selectValue,
+  selectCategory,
+  selectColor,
+  selectAggregateFunction,
+} from "@widget-editor/shared/lib/modules/configuration/selectors";
 
 import TableView from "./component";
 
 export default connectState((state) => ({
-  widgetData: state.editor.widgetData,
-  configuration: state.configuration,
+  widgetData: selectWidgetData(state),
+  value: selectValue(state),
+  category: selectCategory(state),
+  color: selectColor(state),
+  aggregateFunction: selectAggregateFunction(state),
 }))(TableView);

--- a/src/applications/widget-editor/src/components/table-view/index.js
+++ b/src/applications/widget-editor/src/components/table-view/index.js
@@ -1,5 +1,9 @@
 import { connectState } from "@widget-editor/shared/lib/helpers/redux";
-import { selectWidgetData } from "@widget-editor/shared/lib/modules/editor/selectors";
+import {
+  selectWidgetData,
+  selectTableData,
+  selectColumnOptions,
+} from "@widget-editor/shared/lib/modules/editor/selectors";
 import {
   selectValue,
   selectCategory,
@@ -11,6 +15,8 @@ import TableView from "./component";
 
 export default connectState((state) => ({
   widgetData: selectWidgetData(state),
+  tableData: selectTableData(state),
+  columnOptions: selectColumnOptions(state),
   value: selectValue(state),
   category: selectCategory(state),
   color: selectColor(state),

--- a/src/applications/widget-editor/src/components/table-view/style.js
+++ b/src/applications/widget-editor/src/components/table-view/style.js
@@ -34,7 +34,7 @@ export const StyledTd = styled.td`
 `;
 
 export const StyledTh = styled.th`
-  padding: 7px 0;
+  padding: 7px 20px 7px 0;
   font-weight: 700;
   white-space: nowrap;
   border-bottom: 1px solid #d2d3d6;

--- a/src/applications/widget-editor/src/components/table-view/style.js
+++ b/src/applications/widget-editor/src/components/table-view/style.js
@@ -38,4 +38,12 @@ export const StyledTh = styled.th`
   font-weight: 700;
   white-space: nowrap;
   border-bottom: 1px solid #d2d3d6;
+
+  svg {
+    margin-right: 5px;
+
+    path {
+      fill: currentColor;
+    }
+  }
 `;

--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -46,6 +46,19 @@ export default class DataService {
     this.dispatch({ type: sagaEvents.DATA_FLOW_DATASET_WIDGET_READY });
   }
 
+  /**
+   * Fetch the dataset's 50 first rows and set it as the table's data
+   */
+  async getTableData() {
+    const { tableName } = this.dataset.attributes;
+    try {
+      const tableData = await this.adapter.getDatasetData(`SELECT * FROM ${tableName} LIMIT 50`);
+      this.setEditor({ tableData });
+    } catch (e) {
+      console.error("Unable to fetch the dataset's data", e);
+    }
+  }
+
   async restoreEditor(datasetId, widgetId, cb = null) {
     this.setEditor({
       restoring: true
@@ -179,6 +192,7 @@ export default class DataService {
     await this.getDatasetAndWidgets();
     await this.getFieldsAndLayers();
     await this.handleFilters();
+    this.getTableData();
     this.handleEndUserFilters();
     this.dispatch({ type: sagaEvents.DATA_FLOW_VISUALIZATION_READY });
     // If this dispatch is not executed, the local state is not set on init

--- a/src/packages/shared/src/modules/editor/initial-state.js
+++ b/src/packages/shared/src/modules/editor/initial-state.js
@@ -9,5 +9,6 @@ export default {
   enableSave: true,
   widget: null,
   widgetData: [],
+  tableData: [],
   errors: null,
 };

--- a/src/packages/shared/src/modules/editor/selectors.js
+++ b/src/packages/shared/src/modules/editor/selectors.js
@@ -20,6 +20,7 @@ export const selectBasemap = state => state.editor.map?.basemap
   : null;
 export const selectFields = state => state.editor.fields;
 export const selectWidgetData = state => state.editor.widgetData;
+export const selectTableData = state => state.editor.tableData;
 
 export const selectColumnOptions = createSelector(
   [selectFields],

--- a/src/packages/shared/src/modules/editor/selectors.js
+++ b/src/packages/shared/src/modules/editor/selectors.js
@@ -19,6 +19,7 @@ export const selectBasemap = state => state.editor.map?.basemap
   }
   : null;
 export const selectFields = state => state.editor.fields;
+export const selectWidgetData = state => state.editor.widgetData;
 
 export const selectColumnOptions = createSelector(
   [selectFields],


### PR DESCRIPTION
This PR makes the table view smarter by:
- always displaying data (the full table if category or value are not set, and the widget's data otherwise)
- only showing relevant columns (if the user selects the same one for category and value, it is only displayed once)
- adding the “colour” column when it is set
- displaying the aggregation of the columns
- displaying the type of the columns

<p align="center">
<img width="1108" alt="When no widget is constructed yet, the table shows all the columns of the dataset" src="https://user-images.githubusercontent.com/6073968/97451773-fcc52a00-192b-11eb-9ecb-8be0d06eaa18.png">
</p>

## Testing instructions

1. Restore the dataset `852f2275-91a8-4500-9f10-89880dc53f22`
2. Open the table view

The table must display (up to) 50 rows of the dataset. Each column name must be next to an icon representing their type.

3. Select “year_date” on the X axis

The table must still display the same data.

4. Select “number” on the Y axis

The table must now display data for two columns: “year_date” and “number”.

5. Select “number” in the “colour” select

The table must still show the exact same columns.

6. Deselect the “colour” value
7. Select “category” on the Y axis
8. Add a “Count” aggregation

The table must show two columns: “year_date” and “category (Count)”.

9. Select “category” in the “colour” select

The table must show 3 columns: “year_date”, “category (Count)” and “category”.

10. Select “year_date” in the “colour” select

The table must only show two columns: “year_date” and “category (Count)”

11. Select “category” on the X axis and in the “colour” select

The table must show two columns: “category” and “category (Count)”

12. Remove the aggregation

Only one column must be shown: “category”.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/173900552).
