### PR TITLE
fixes wrong map bounds array

### DIFF
--- a/src/packages/map/src/index.js
+++ b/src/packages/map/src/index.js
@@ -243,8 +243,8 @@ class Map extends React.Component {
     if (mapOptions.bbox && Array.isArray(mapOptions.bbox)) {
       const [b0, b1, b2, b3] = mapOptions.bbox;
       this.map.fitBounds([
-        [b1, b0],
-        [b3, b2]
+        [b0, b1],
+        [b2, b3]
       ], { animate: false });
     } else if (this.props?.mapConfig?.bounds) {
       // Legacy editor stores "bounds"


### PR DESCRIPTION
⚠️ Before submitting the PR, make sure:

- You ran the tests: `yarn test`
- You updated the changelog
- You asked someone to review it
- You chose a meaningful title

---

This PR fixes an issue fitting the bounds of a map-type widget.

## Testing instructions

In the playground, you can test with [this widget](http://api.resourcewatch.org/v1/widget/7072610f-e903-464e-b2b2-1bd1f92afa57). Without the change, the bounds will point to the South Pole independently of the bounds set by the user after changing them and reload.

## Pivotal Tracker

https://www.pivotaltracker.com/story/show/175492760
