### PR TITLE
Change the behaviour of the slice count setting

### DIFF
--- a/src/packages/core/src/charts/pie.ts
+++ b/src/packages/core/src/charts/pie.ts
@@ -144,7 +144,7 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
             // not dynamically updated when the filters change)
             "expr": endUserFilters.length
               ? 'datum.x'
-              : `datum.rank < ${configuration.sliceCount} ? datum.x : 'Others'`
+              : `datum.rank < ${configuration.sliceCount + 1} ? datum.x : 'Others'`
           },
           {
             "type": "aggregate",
@@ -176,7 +176,7 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
             // not dynamically updated when the filters change)
             "expr": endUserFilters.length
               ? 'datum.x'
-              : `datum.rank < ${configuration.sliceCount} ? datum.x : 'Others'`
+              : `datum.rank < ${configuration.sliceCount + 1} ? datum.x : 'Others'`
           },
           {
             "type": "aggregate",
@@ -219,14 +219,16 @@ export default class Pie extends ChartsCommon implements Charts.Pie {
           type: 'string'
         }));
     } else {
-      values = uniqBy(
-        widgetData.map((d: { x: any }, i) => ({ ...d, x: i + 1 < configuration.sliceCount ? d.x : 'Others' })),
-        'x'
-      )
-        .slice(0, configuration.sliceCount)
+      values = uniqBy(widgetData.map(
+        (d: { x: any }, i) => ({
+          ...d,
+          x: i < configuration.sliceCount ? d.x : 'Others'
+        })
+      ), 'x')
+        .slice(0, configuration.sliceCount + 1)
         .map((d: { [key: string]: any }, i) => ({
           label: d.x,
-          value: scheme.range.category20[i % configuration.sliceCount],
+          value: scheme.range.category20[i % (configuration.sliceCount + 1)],
           type: 'string'
         }));
     }


### PR DESCRIPTION
Up until now, if the user would set the slice count setting to 5, we would display 4 slices with their respective value and a 5th with the label “Others”. This PR changes the behaviour so that 5 slices are displayed with their value and a 6th is the “Others” one.

## Testing instructions

1. Restore the dataset `852f2275-91a8-4500-9f10-89880dc53f22`
2. Create a pie chart used twice the column “number”

By default the slice count setting will have a value of 6. Make sure 7 slices are displayed and that the last one is “Others”.

3. Change the value of the slice count setting

Make sure the ratio is kept (i.e. one additional slice is “Others”).

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175349592).
