### PR TITLE
Only display relevant chart specific settings

### DIFF
--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -70,6 +70,7 @@ const EditorOptions = ({
   compact,
   dataService,
   isMap,
+  chartType,
 }) => {
   const tabsVisibility = useMemo(() => ({
     general: true,
@@ -151,16 +152,19 @@ const EditorOptions = ({
                 )}
               </AccordionSection>
             )}
-            {!isMap && !rasterOnly && !advanced && (
+            {!isMap && !rasterOnly && !advanced
+              && (chartType === 'pie' || chartType === 'donut') && (
               <AccordionSection title="Chart specific">
-                <Suspense fallback={<div>Loading...</div>}>
-                  {donutRadius && (
-                    <DonutRadius
-                      value={donutRadius}
-                      onChange={(value) => handleDonutRadius(value)}
-                    />
-                  )}
-                </Suspense>
+                {chartType === 'donut' && (
+                  <Suspense fallback={<div>Loading...</div>}>
+                    {donutRadius && (
+                      <DonutRadius
+                        value={donutRadius}
+                        onChange={(value) => handleDonutRadius(value)}
+                      />
+                    )}
+                  </Suspense>
+                )}
                 <Suspense fallback={<div>Loading...</div>}>
                   {sliceCount && data && (
                     <SliceCount

--- a/src/applications/widget-editor/src/components/editor-options/index.js
+++ b/src/applications/widget-editor/src/components/editor-options/index.js
@@ -1,6 +1,6 @@
 import { connectState } from "@widget-editor/shared/lib/helpers/redux";
 import { patchConfiguration } from "@widget-editor/shared/lib/modules/configuration/actions";
-import { isMap } from "@widget-editor/shared/lib/modules/configuration/selectors";
+import { selectChartType, isMap } from "@widget-editor/shared/lib/modules/configuration/selectors";
 import {
   selectDisabledFeatures,
   selectAdvanced,
@@ -23,6 +23,7 @@ export default connectState(
     donutRadius: state.configuration.donutRadius,
     sliceCount: state.configuration.sliceCount,
     isMap: isMap(state),
+    chartType: selectChartType(state),
     data: state.editor.widgetData,
     orderBy: state.configuration.orderBy,
     compact: state.theme.compact,

--- a/src/applications/widget-editor/src/components/slice-count/component.js
+++ b/src/applications/widget-editor/src/components/slice-count/component.js
@@ -34,7 +34,7 @@ const SliceCount = ({
   return (
     <InputGroup>
       <FormLabel htmlFor="options-slice-count">
-        Slice count (donut and pie charts)
+        Slice count
       </FormLabel>
       <FlexContainer row={true}>
         <FlexController shrink="0">


### PR DESCRIPTION
This PR removes the chart specific settings from the UI when they are not relevant for the current view.

## Testing instructions

1. Restore any dataset (keep the default chart selection)

The “Chart specific” section should be hidden.

2. Select the pie visualisation type

The section must now appear and contain the “Slice count” setting.

3. Select the doughnut visualization type

The section must now contain two settings: “Donut radius” and “Slice count”.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175349623).
