### PR TITLE
Add the geographic filter back

### DIFF
--- a/src/adapters/rw-adapter/src/helpers/config.ts
+++ b/src/adapters/rw-adapter/src/helpers/config.ts
@@ -11,14 +11,11 @@ class ConfigHelper implements Config.Service {
 
   setConfig(params: Config.Payload): void {
     const acceptedParams = pick(params, [
-      "url",
+      "endpoint",
       "env",
       "applications",
-      "authUrl",
-      "assetsPath",
-      "userToken",
-      "userEmail",
       "locale",
+      "userToken",
     ]);
     this.config = { ...this.config, ...acceptedParams };
   }

--- a/src/adapters/rw-adapter/src/index.ts
+++ b/src/adapters/rw-adapter/src/index.ts
@@ -275,7 +275,7 @@ export default class RwAdapter implements Adapter.Service {
 
     // We save the URL of the data so it is exposed by the public method getDataUrl
     // This is the reason why we don't use getDatasetData to fetch the data
-    this.dataUrl = `${this.endpoint}/query/${this.datasetId}?sql=${filtersService.getQuery()}`;
+    this.dataUrl = `${this.endpoint}/query/${this.datasetId}?sql=${filtersService.getQuery()}${filtersService.getAdditionalParams()}`;
     const { data: { data } } = await this.prepareRequest(this.dataUrl);
 
     return data
@@ -321,5 +321,18 @@ export default class RwAdapter implements Adapter.Service {
       mainColor: config.range.category20[0],
       category: config.range.category20,
     };
+  }
+
+  async getPredefinedAreas(): Promise<{ id: string, name: string }[]> {
+    const url = `${this.endpoint}/geostore/admin/list`;
+    const { data: { data } } = await this.prepareRequest(url);
+
+    return data
+      .filter(({ name }) => !!name)
+      .map(({ geostoreId: id, name }) => ({
+        id,
+        name,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 }

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -253,7 +253,8 @@ EditorOptions.propTypes = {
   donutRadius: PropTypes.number,
   sliceCount: PropTypes.number,
   data: PropTypes.any,
-  orderBy: PropTypes.string
-}
+  orderBy: PropTypes.string,
+  hasGeoInfo: PropTypes.bool.isRequired,
+};
 
 export default EditorOptions;

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -10,6 +10,7 @@ import WidgetInfo from "components/widget-info";
 import OrderValues from "components/order-values";
 import QueryLimit from "components/query-limit";
 import Filter from "components/filter";
+import GeoFilter from "components/geo-filter";
 import EndUserFilters from "components/end-user-filters";
 
 import { DEFAULT_BORDER } from "@widget-editor/shared/lib/styles/style-constants";
@@ -72,6 +73,7 @@ const EditorOptions = ({
   dataService,
   isMap,
   chartType,
+  hasGeoInfo,
 }) => {
   const tabsVisibility = useMemo(() => ({
     general: true,
@@ -132,6 +134,11 @@ const EditorOptions = ({
             {!isMap && !advanced && (
               <AccordionSection title="Filters">
                 <Filter dataService={dataService} />
+              </AccordionSection>
+            )}
+            {!isMap && !advanced && hasGeoInfo && disabledFeatures.indexOf("geo-filter") === -1 && (
+              <AccordionSection title="Geographic filter">
+                <GeoFilter dataService={dataService} />
               </AccordionSection>
             )}
             {!isMap && !advanced && disabledFeatures.indexOf("end-user-filters") === -1 && (

--- a/src/applications/widget-editor/src/components/editor-options/index.js
+++ b/src/applications/widget-editor/src/components/editor-options/index.js
@@ -4,6 +4,7 @@ import { selectChartType, isMap } from "@widget-editor/shared/lib/modules/config
 import {
   selectDisabledFeatures,
   selectAdvanced,
+  selectHasGeoInfo,
 } from "@widget-editor/shared/lib/modules/editor/selectors";
 
 import EditorOptionsComponent from "./component";
@@ -27,6 +28,7 @@ export default connectState(
     data: state.editor.widgetData,
     orderBy: state.configuration.orderBy,
     compact: state.theme.compact,
+    hasGeoInfo: selectHasGeoInfo(state),
   }),
   { patchConfiguration }
 )(EditorOptionsComponent);

--- a/src/applications/widget-editor/src/components/geo-filter/component.js
+++ b/src/applications/widget-editor/src/components/geo-filter/component.js
@@ -1,0 +1,62 @@
+import React, { useState, useCallback, useEffect } from "react";
+import PropTypes from "prop-types";
+
+import { Select } from "@widget-editor/shared";
+
+const GeoFilter = ({ dataService, areaIntersection, setFilters, patchConfiguration }) => {
+  const [predefinedAreasOptions, setPredefinedAreasOptions] = useState([]);
+  const [selectedOption, setSelectedOption] = useState(null);
+
+  const onChangeArea = useCallback((option) => {
+    setFilters({ areaIntersection: option?.value ?? null });
+    patchConfiguration();
+  }, [patchConfiguration, setFilters]);
+
+  useEffect(() => {
+    const fetchAreas = async () => {
+      const options = (await dataService.getPredefinedAreas())
+        .map(({ id, name }) => ({
+          label: name,
+          value: id,
+        }));
+
+      setPredefinedAreasOptions(options);
+    };
+
+    fetchAreas();
+  }, [dataService, setPredefinedAreasOptions]);
+
+  useEffect(() => {
+    if (!areaIntersection) {
+      setSelectedOption(null);
+    } else {
+      setSelectedOption(predefinedAreasOptions.find(option => option.value === areaIntersection));
+    }
+  }, [areaIntersection, predefinedAreasOptions, setSelectedOption]);
+  
+  return (
+    <Select
+      id="geo-filter"
+      name="geo-filter"
+      aria-label="Select an area"
+      placeholder="Select an area"
+      value={selectedOption}
+      options={predefinedAreasOptions}
+      onChange={onChangeArea}
+      isClearable
+    />
+  );
+};
+
+GeoFilter.propTypes = {
+  dataService: PropTypes.object.isRequired,
+  areaIntersection: PropTypes.string,
+  setFilters: PropTypes.func.isRequired,
+  patchConfiguration: PropTypes.func.isRequired,
+};
+
+GeoFilter.defaultProps = {
+  areaIntersection: null,
+};
+
+export default GeoFilter;

--- a/src/applications/widget-editor/src/components/geo-filter/component.js
+++ b/src/applications/widget-editor/src/components/geo-filter/component.js
@@ -53,10 +53,22 @@ const GeoFilter = ({ dataService, areaIntersection, setFilters, patchConfigurati
     if (!areaIntersection) {
       setSelectedOption(null);
     } else {
-      const option = [
+      let option = [
         ...predefinedAreasOptions,
         ...userAreasOptions,
       ].find(option => option.value === areaIntersection);
+
+      if (!option) {
+        // This case happens when we restore a widget that was created with a user's area and the
+        // editor doesn't receive the user's token
+        // We can still use the area to filter, but we don't have its name so we create this new
+        // option
+        option = {
+          label: 'Custom area',
+          value: areaIntersection,
+        };
+      }
+
       setSelectedOption(option);
     }
   }, [areaIntersection, predefinedAreasOptions, userAreasOptions, setSelectedOption]);

--- a/src/applications/widget-editor/src/components/geo-filter/index.js
+++ b/src/applications/widget-editor/src/components/geo-filter/index.js
@@ -1,0 +1,15 @@
+import { redux } from "@widget-editor/shared";
+import { selectAreaIntersection } from "@widget-editor/shared/lib/modules/filters/selectors";
+import { setFilters } from "@widget-editor/shared/lib/modules/filters/actions";
+import { patchConfiguration } from "@widget-editor/shared/lib/modules/configuration/actions";
+import Component from "./component";
+
+export default redux.connectState(
+  state => ({
+    areaIntersection: selectAreaIntersection(state),
+  }),
+  {
+    setFilters,
+    patchConfiguration,
+  },
+)(Component);

--- a/src/packages/core/src/output-payload/index.ts
+++ b/src/packages/core/src/output-payload/index.ts
@@ -12,7 +12,6 @@ import {
   selectOrderBy,
   selectAggregateFunction,
   selectChartType,
-  selectAreaIntersection,
   selectBand,
   selectDonutRadius,
   selectSliceCount,
@@ -29,7 +28,10 @@ import {
   selectBbox,
   selectBasemap,
 } from '@widget-editor/shared/lib/modules/editor/selectors';
-import { selectFiltersList } from '@widget-editor/shared/lib/modules/filters/selectors';
+import {
+  selectFiltersList,
+  selectAreaIntersection,
+} from '@widget-editor/shared/lib/modules/filters/selectors';
 import { selectEndUserFilters } from '@widget-editor/shared/lib/modules/end-user-filters/selectors';
 import { getSerializedFilters } from '../filters';
 

--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -210,4 +210,16 @@ export default class DataService {
       return [];
     }
   }
+
+  /**
+   * Return the list of the user's areas
+   */
+  async getUserAreas(): Promise<{ id: string | number, name: string }[]> {
+    try {
+      return await this.adapter.getUserAreas();
+    } catch (e) {
+      console.error("Unable to fetch the user's areas", e);
+      return [];
+    }
+  }
 }

--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -72,6 +72,7 @@ export default class DataService {
     await this.getFieldsAndLayers();
     await this.handleFilters();
     this.handleEndUserFilters();
+    this.handleGeoFilter();
 
     this.setEditor({
       widgetData: [],
@@ -142,6 +143,20 @@ export default class DataService {
       this.dispatch({
         type: reduxActions.EDITOR_SET_END_USER_FILTERS,
         payload: endUserFilters,
+      })
+    }
+  }
+
+  handleGeoFilter(): void {
+    if (!this.widget) {
+      return;
+    }
+
+    const areaIntersection = this.widget.attributes?.widgetConfig?.paramsConfig?.areaIntersection;
+    if (areaIntersection) {
+      this.dispatch({
+        type: reduxActions.EDITOR_SET_FILTERS,
+        payload: { areaIntersection },
       })
     }
   }

--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -198,4 +198,16 @@ export default class DataService {
     // If this dispatch is not executed, the local state is not set on init
     this.dispatch({ type: sagaEvents.DATA_FLOW_RESTORED });
   }
+
+  /**
+   * Return the list of predefined areas the user can filter with
+   */
+  async getPredefinedAreas(): Promise<{ id: string | number, name: string }[]> {
+    try {
+      return await this.adapter.getPredefinedAreas();
+    } catch (e) {
+      console.error("Unable to fetch the predefined areas", e);
+      return [];
+    }
+  }
 }

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -12,7 +12,7 @@ import FieldsService from "./fields";
 
 export default class FiltersService implements Filters.Service {
   sql: string;
-  additionalParams: string[] = [];
+  additionalParams: [string, string][] = [];
   dataset: any;
   configuration: Config.Payload;
   adapter: Adapter.Service;
@@ -306,7 +306,7 @@ export default class FiltersService implements Filters.Service {
   prepareGeostore() {
     const { areaIntersection } = this.filters;
     if (areaIntersection) {
-      this.additionalParams.push(`geostore=${areaIntersection}`);
+      this.additionalParams.push(['geostore', areaIntersection]);
     }
   }
 
@@ -319,7 +319,7 @@ export default class FiltersService implements Filters.Service {
       return '';
     }
 
-    return `&${this.additionalParams.map(p => encodeURIComponent(p)).join('&')}`;
+    return `&${this.additionalParams.map(param => `${param[0]}=${encodeURIComponent(param[1])}`).join('&')}`;
   }
 
   /**

--- a/src/packages/core/src/services/state-proxy.ts
+++ b/src/packages/core/src/services/state-proxy.ts
@@ -24,7 +24,7 @@ export default class StateProxy {
     const { prev, next } = this.getStateDiff(state);
     return !isEqual(
       prev.configuration.aggregateFunction, next.configuration.aggregateFunction ||
-      !isEqual(prev.configuration.orderBy, next.configuration.orderBy)
+    !isEqual(prev.configuration.orderBy, next.configuration.orderBy)
     );
   }
 
@@ -72,6 +72,8 @@ export default class StateProxy {
 
     // If filters change
     shouldUpdate = shouldUpdate || !isEqual(prev.filters.list, next.filters.list);
+    shouldUpdate = shouldUpdate
+      || !isEqual(prev.filters.areaIntersection, next.filters.areaIntersection);
 
     // If the end-user filters change
     shouldUpdate = shouldUpdate || !isEqual(prev.endUserFilters, next.endUserFilters);

--- a/src/packages/shared/src/modules/configuration/selectors.js
+++ b/src/packages/shared/src/modules/configuration/selectors.js
@@ -16,7 +16,6 @@ export const selectOrderBy = state => state.configuration.orderBy;
 export const selectAggregateFunction = state => state.configuration.aggregateFunction;
 export const selectChartType = state => state.configuration.chartType;
 export const selectFilters = state => state.configuration.filters;
-export const selectAreaIntersection = state => state.configuration.areaIntersection;
 export const selectBand = state => state.configuration.band;
 export const selectDonutRadius = state => state.configuration.donutRadius;
 export const selectSliceCount = state => state.configuration.sliceCount;

--- a/src/packages/shared/src/modules/editor/selectors.js
+++ b/src/packages/shared/src/modules/editor/selectors.js
@@ -5,6 +5,7 @@ import { getLocalCache } from '@widget-editor/widget-editor/lib/exposed-hooks';
 
 export const selectDisabledFeatures = state => state.editor.disabledFeatures;
 export const selectAdvanced = state => state.editor.advanced;
+export const selectDataset = state => state.editor.dataset;
 export const selectWidget = state => state.editor.widget;
 export const selectZoom = state => state.editor.map?.zoom ?? null;
 export const selectLat = state => state.editor.map?.lat ?? null;
@@ -63,4 +64,9 @@ export const selectIsEditing = createSelector(
 export const selectIsWidgetAdvanced = createSelector(
   [selectWidget],
   widget => !!widget && !widget?.attributes?.widgetConfig?.paramsConfig,
+);
+
+export const selectHasGeoInfo = createSelector(
+  [selectDataset],
+  dataset => !!dataset && dataset.attributes?.geoInfo,  
 );

--- a/src/packages/shared/src/modules/filters/initial-state.js
+++ b/src/packages/shared/src/modules/filters/initial-state.js
@@ -1,5 +1,6 @@
 export default {
   loading: false,
+  areaIntersection: null,
   orderBy: null,
   color: null,
   list: []

--- a/src/packages/shared/src/modules/filters/selectors.js
+++ b/src/packages/shared/src/modules/filters/selectors.js
@@ -1,1 +1,2 @@
 export const selectFiltersList = state => state.filters.list;
+export const selectAreaIntersection = state => state.filters.areaIntersection;

--- a/src/packages/types/src/adapter.ts
+++ b/src/packages/types/src/adapter.ts
@@ -36,4 +36,5 @@ export interface Service {
   setDatasetId(datasetId: datasetId): void;
   getSerializedScheme(config: Widget.Scheme): any;
   getDeserializedScheme(config: any): Widget.Scheme;
+  getPredefinedAreas(): Promise<{ id: Id, name: string }[]>;
 }

--- a/src/packages/types/src/adapter.ts
+++ b/src/packages/types/src/adapter.ts
@@ -6,6 +6,7 @@ import * as Config from "./config";
 type Id = string | number;
 type WidgetId = Id;
 type Endpoint = string;
+export type Area = { id: Id, name: string };
 
 export type datasetId = Id;
 
@@ -36,5 +37,6 @@ export interface Service {
   setDatasetId(datasetId: datasetId): void;
   getSerializedScheme(config: Widget.Scheme): any;
   getDeserializedScheme(config: any): Widget.Scheme;
-  getPredefinedAreas(): Promise<{ id: Id, name: string }[]>;
+  getPredefinedAreas(): Promise<Area[]>;
+  getUserAreas(): Promise<Area[]>;
 }

--- a/src/packages/types/src/filters.ts
+++ b/src/packages/types/src/filters.ts
@@ -7,6 +7,8 @@ export interface Service {
   prepareGroupBy(): void;
   prepareOrderBy(): void;
   prepareLimit(): void;
+  getQuery(): string;
+  getAdditionalParams(): string;
 }
 
 type GenericFilter<T> = {


### PR DESCRIPTION
This PR implements the new geographic filter which was present in v1.

<p align="center">
<img width="1108" alt="Editor with the new geographic filter set to “Newcastle” and a column chart on the left with two bars representing regions of Newcastle" src="https://user-images.githubusercontent.com/6073968/97991417-59678f80-1dd9-11eb-8f7c-efa585ce9e47.png">
</p>

This implementation has been simplified to only allow the users to select predefined areas or their own if they have some and the host app has passed the adapter their token.

To fetch the user's areas, the adapter needs the `userToken` to be set. This can be achieved with the `AdapterModifier` function.

Note that the “Geographic filter” setting is only present when the dataset has been tagged as having geographic information.

## Testing instructions

1. Restore the dataset `852f2275-91a8-4500-9f10-89880dc53f22`

The editor mustn't display the “Geographic filter” section as this dataset doesn't have geographic information.

2. Restore the dataset `5e156d22-7f84-4cd2-9724-c1a519a83e0a`

The editor must display the “Geographic filter” section.

3. Create a column chart with “Name” on the X axis and “Maximum Population” on the Y axis
4. Select “Spain” in the geographic filter

Make sure the chart is updated and that all the columns represent cities in Spain.

5. In [My Resource Watch](https://resourcewatch.org/myrw/areas), create a custom area by drawing on the map
6. In `src/playground/widget-editor/src/components/editor/component.js`, replace the adapter by: `AdapterModifier(RwAdapter, { userToken: 'XXX' })` where `XXX` is your token (without the “Bearer” part)
7. Reload the editor with the same dataset
8. Select your custom area in the geographic filter

Make sure the columns are correctly filtered according to the area you've drawn.

9. Restore the widget `df070ec2-b913-4d80-ae51-923694a9a250` (dataset: `5e156d22-7f84-4cd2-9724-c1a519a83e0a`)

This widget has been created with one of my own custom areas. Because you don't have my token, you cannot see its name, but you can still use it to filter the widget.

Make sure the widget shows two columns: “Sunderland” and “Middlesbrough” and that the option is displayed as “Custom area” in the select.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/171055466).
