### PR TITLE
Fix a bug where the full table view wouldn't be updated when the dataset would change

### DIFF
--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -73,6 +73,8 @@ export default class DataService {
     await this.handleFilters();
     this.handleEndUserFilters();
 
+    this.getTableData();
+
     this.setEditor({
       widgetData: [],
       advanced: !this.widget?.attributes?.widgetConfig


### PR DESCRIPTION
This PR fixes an issue where, when the editor receives a new dataset, the data of the full table view is not refetched.

## Testing instructions

1. Restore the editor with a dataset
2. Open the table view

The table must show data.

3. Restore the editor with a different dataset (using the playground's settings)
4. Open the table view

The table must also show data.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175537421).
