### PR TITLE
Fix a bug which would allow the user to create filters with an already used column

### DIFF
--- a/src/applications/widget-editor/src/components/filter/component.js
+++ b/src/applications/widget-editor/src/components/filter/component.js
@@ -32,9 +32,17 @@ const Filter = ({
   dataset,
   loading
 }) => {
+  const availableColumnOptions = useMemo(() => {
+    const usedColumns = filters.map(filter => filter.column).filter(column => !!column);
+    return columnOptions.map(option => ({
+      ...option,
+      isDisabled: usedColumns.indexOf(option.value) !== -1,
+    }))
+  }, [columnOptions, filters]);
+
   const canAddFilter = useMemo(
-    () => filters.length < columnOptions.length && filters.every(filter => filter.column),
-    [filters, columnOptions]
+    () => filters.length < availableColumnOptions.length && filters.every(filter => filter.column),
+    [filters, availableColumnOptions]
   );
 
   const addFilter = useCallback(() => setFilters({
@@ -96,8 +104,8 @@ const Filter = ({
               aria-label="Select a column"
               placeholder="Select a column"
               loading={loading}
-              value={columnOptions.find(({ value }) => value === filter.column)}
-              options={columnOptions}
+              value={availableColumnOptions.find(({ value }) => value === filter.column)}
+              options={availableColumnOptions}
               onChange={
                 ({ value, type }) => updateFilter(filter.id, { column: value, type })
               }

--- a/src/packages/shared/src/components/select/style.js
+++ b/src/packages/shared/src/components/select/style.js
@@ -116,6 +116,7 @@ export default {
       ...provided,
       color,
       backgroundColor,
+      opacity: state.isDisabled ? 0.4 : 1,
     };
   },
 


### PR DESCRIPTION
This PR fixes an issue where the user could use a column multiple times to create filters.

The first commit disables already used columns in the select and the second one updates the style of the disabled options so they appear faded out.

## Testing instructions

1. Create a filter based on a column
2. Click the “Add filter” button again

Make sure the column you used for the first filter can't be selected again in the select.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175558046).
