### PR TITLE
add ide linting support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 **/node_modules
 **/lib
 **/build
+config-overrides.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,7 @@
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+    "no-unused-vars": ["error", { "ignoreRestSiblings": true }]
   }
 }

--- a/src/applications/renderer/.eslintrc.js
+++ b/src/applications/renderer/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  'extends': [
+    '@widget-editor/eslint-config',
+  ]
+};

--- a/src/applications/renderer/.lintstagedrc.js
+++ b/src/applications/renderer/.lintstagedrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "*.js": "eslint"
+}

--- a/src/applications/renderer/package.json
+++ b/src/applications/renderer/package.json
@@ -43,7 +43,8 @@
     "@babel/cli": "^7.7.5",
     "@babel/core": "^7.7.5",
     "@babel/preset-react": "^7.7.4",
-    "babel-plugin-module-resolver": "^4.0.0"
+    "babel-plugin-module-resolver": "^4.0.0",
+    "@widget-editor/eslint-config": "^0.0.0"
   },
   "scripts": {
     "start": "BABEL_ENV=development babel src --extensions .ts,.tsx,.js --out-dir lib --copy-files --config-file ./babel.config.js --watch",

--- a/src/applications/renderer/src/components/column-selections/component.js
+++ b/src/applications/renderer/src/components/column-selections/component.js
@@ -10,7 +10,6 @@ import { formatOptionLabel } from "./utils";
 import { StyledBottomSelect, StyledLeftSelect, SelectStyles } from "./style";
 
 const ColumnSelections = ({
-  compact,
   columns,
   configuration,
   patchConfiguration,

--- a/src/applications/renderer/src/components/select-chart/components/ChartIcon/component.js
+++ b/src/applications/renderer/src/components/select-chart/components/ChartIcon/component.js
@@ -29,7 +29,7 @@ const ChartIcon = ({
   type = TYPE_BAR,
   active = false,
   disabled = false,
-  setData = (data) => {},
+  setData = () => {},
 }) => {
   return (
     <StyledBox>

--- a/src/applications/widget-editor/.eslintrc.js
+++ b/src/applications/widget-editor/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  'extends': [
+    '@widget-editor/eslint-config',
+  ]
+};

--- a/src/applications/widget-editor/.lintstagedrc.js
+++ b/src/applications/widget-editor/.lintstagedrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "*.js": "eslint"
+}

--- a/src/applications/widget-editor/package.json
+++ b/src/applications/widget-editor/package.json
@@ -51,7 +51,8 @@
     "@babel/core": "^7.7.5",
     "@babel/preset-react": "^7.7.4",
     "babel-plugin-module-resolver": "^4.0.0",
-    "rollup-plugin-css-porter": "^1.0.2"
+    "rollup-plugin-css-porter": "^1.0.2",
+    "@widget-editor/eslint-config": "^0.0.0"
   },
   "scripts": {
     "start": "NODE_ENV=development babel src --extensions .ts,.tsx,.js --out-dir lib --copy-files --config-file ./babel.config.js --watch",

--- a/src/applications/widget-editor/src/components/advanced-editor/style.js
+++ b/src/applications/widget-editor/src/components/advanced-editor/style.js
@@ -30,7 +30,7 @@ export const ValidationCallout = styled(StyledCallout)`
   margin-top: 20px;
   border: 1px solid #ff4141;
   border-radius: 4px;
-  background-color: ${props => tinycolor('#ff4141').setAlpha(0.05).toRgbString()};
+  background-color: ${() => tinycolor('#ff4141').setAlpha(0.05).toRgbString()};
 
   ul {
     padding-left: 1em;

--- a/src/applications/widget-editor/src/components/donut-radius/component.js
+++ b/src/applications/widget-editor/src/components/donut-radius/component.js
@@ -16,8 +16,7 @@ const DonutRadius = ({
   min = 1,
   max = 150,
   value = 40,
-  minDistance = 1,
-  onChange = (data) => {},
+  onChange = () => {},
 }) => {
   const [localValue, setLocalValue] = useState({ value, key: null });
 

--- a/src/applications/widget-editor/src/components/editor-options/component.js
+++ b/src/applications/widget-editor/src/components/editor-options/component.js
@@ -66,7 +66,6 @@ const EditorOptions = ({
   donutRadius,
   sliceCount,
   data,
-  orderBy,
   patchConfiguration,
   compact,
   dataService,

--- a/src/applications/widget-editor/src/components/slice-count/component.js
+++ b/src/applications/widget-editor/src/components/slice-count/component.js
@@ -13,9 +13,7 @@ import InputInfo from "styles-common/input-info";
 const SliceCount = ({
   min = 1,
   value = null,
-  data = null,
-  minDistance = 1,
-  onChange = (data) => {},
+  onChange = () => {},
   disabledFeatures,
 }) => {
   const [localValue, setLocalValue] = useState({ value: value, key: null });

--- a/src/applications/widget-editor/src/components/slider/component.js
+++ b/src/applications/widget-editor/src/components/slider/component.js
@@ -21,7 +21,6 @@ const Slider = ({
   max = 500,
   step = 1,
   value,
-  defaultValue,
   theme,
   onChange = () => {},
   onDone = () => {},

--- a/src/applications/widget-editor/src/sagas/widget/index.js
+++ b/src/applications/widget-editor/src/sagas/widget/index.js
@@ -57,7 +57,7 @@ function* initializeData(props) {
  * Generates a vega configuration that is displayed within the renderer
  * @triggers <void>
  */
-function* initializeVega(props) {
+function* initializeVega() {
   const { widgetEditor: store } = yield select();
   const { editor, widgetConfig } = store;
   const { advanced } = editor;
@@ -76,7 +76,7 @@ function* initializeVega(props) {
    * Traditional widgets
    * Using: @core VegaService
    * DataService has figured out how a widget will be configured
-   * VegaService utilizes store properties and generates a vega config for us
+   * VegaService utilises store properties and generates a vega config for us
    */
   if (!advanced && !isMap(store)) {
     const vega = new VegaService(store);
@@ -172,7 +172,7 @@ export default function* baseSaga() {
   /**
    * Trigger initial data request
    * @sagaEvents DATA_FLOW_VISUALIZATION_READY
-   * Will resolve sql query and any editor state requried for rendering a widget
+   * Will resolve sql query and any editor state required for rendering a widget
    * @triggers > EDITOR/dataInitialized
    */
   yield takeLatest(

--- a/src/packages/eslint-config/index.js
+++ b/src/packages/eslint-config/index.js
@@ -1,0 +1,5 @@
+// We simply include our root eslint config and extend it for each package
+// We keep a root config so we don't have to change it in multiple places
+// This package is simply used to give linting capability locally when developing
+const eslintConf = require("../../../.eslintrc.json");
+module.exports = eslintConf;

--- a/src/packages/eslint-config/package.json
+++ b/src/packages/eslint-config/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@widget-editor/eslint-config",
+  "version": "0.0.0",
+  "description": "Shareable ESLint configuration",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "private": true,
+  "main": "index.js",
+  "devDependencies": {
+    "eslint-plugin-babel": "^5.3.1",
+    "eslint-plugin-jest": "^24.1.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  }
+}

--- a/src/packages/map/.eslintrc.js
+++ b/src/packages/map/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  'extends': [
+    '@widget-editor/eslint-config',
+  ]
+};

--- a/src/packages/map/.lintstagedrc.js
+++ b/src/packages/map/.lintstagedrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "*.js": "eslint"
+}

--- a/src/packages/map/package.json
+++ b/src/packages/map/package.json
@@ -30,7 +30,8 @@
     "@babel/core": "^7.7.5",
     "@babel/preset-react": "^7.7.4",
     "babel-plugin-module-resolver": "^4.0.0",
-    "webpack-cli": "^3.3.11"
+    "webpack-cli": "^3.3.11",
+    "@widget-editor/eslint-config": "^0.0.0"
   },
   "scripts": {
     "start": "BABEL_ENV=development babel src --extensions .ts,.tsx,.js --out-dir lib --copy-files --config-file ./babel.config.js --watch",

--- a/src/packages/map/src/helpers/layer-manager.js
+++ b/src/packages/map/src/helpers/layer-manager.js
@@ -1,5 +1,3 @@
-/* eslint import/no-unresolved: 0 */
-/* eslint import/extensions: 0 */
 /* eslint global-require: 0 */
 
 export default class LayerManager {

--- a/src/packages/shared/.eslintrc.js
+++ b/src/packages/shared/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  'extends': [
+    '@widget-editor/eslint-config',
+  ]
+};

--- a/src/packages/shared/.lintstagedrc.js
+++ b/src/packages/shared/.lintstagedrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "*.js": "eslint"
+}

--- a/src/packages/shared/package.json
+++ b/src/packages/shared/package.json
@@ -39,7 +39,8 @@
     "@babel/core": "^7.7.5",
     "@babel/preset-react": "^7.7.4",
     "babel-plugin-module-resolver": "^4.0.0",
-    "webpack-cli": "^3.3.11"
+    "webpack-cli": "^3.3.11",
+    "@widget-editor/eslint-config": "^0.0.0"
   },
   "scripts": {
     "start": "BABEL_ENV=development babel src --extensions .ts,.tsx,.js --out-dir lib --copy-files --config-file ./babel.config.js --watch",

--- a/src/packages/shared/src/components/select/style.js
+++ b/src/packages/shared/src/components/select/style.js
@@ -72,7 +72,7 @@ export default {
     }
   },
 
-  singleValue: (provided, state) => {
+  singleValue: (provided) => {
     const maxWidth = 'calc(100% - 90px)';
     return { ...provided, maxWidth };
   },
@@ -81,7 +81,7 @@ export default {
     display: "none",
   }),
 
-  dropdownIndicator: (provided, state) => {
+  dropdownIndicator: () => {
     return {
       color: "#c32d7b",
       transition: "all 0.2s ease-out",

--- a/src/packages/shared/src/modules/configuration/reducers.js
+++ b/src/packages/shared/src/modules/configuration/reducers.js
@@ -3,7 +3,7 @@ import * as actions from "./actions";
 import initialState from './initial-state';
 
 export default {
-  [actions.resetConfiguration]: (state) => ({ ...initialState }),
+  [actions.resetConfiguration]: () => ({ ...initialState }),
   [actions.setConfiguration]: (state, { payload }) => ({
     ...state,
     ...payload

--- a/src/playground/widget-editor/src/components/editor-form/useEditorForm.js
+++ b/src/playground/widget-editor/src/components/editor-form/useEditorForm.js
@@ -113,7 +113,7 @@ export default function useEditorForm(autoFillValue) {
   const isCustomDataset = !datasets.find(d => d.value === dataset.value);
 
   // Event handlers for select inputs
-  const handleChangeDataset = async (item, { action }) => {
+  const handleChangeDataset = async (item) => {
     if (item?.value) {
       const allWidgets = await getAllWidgetsForDataset(item.value);
       dispatch(modifyOptions({
@@ -129,7 +129,7 @@ export default function useEditorForm(autoFillValue) {
     }
   }
 
-  const handleChangeWidget = async (item, { action }) => {
+  const handleChangeWidget = async (item) => {
     dispatch(modifyOptions({
       widget: item.value
     }))


### PR DESCRIPTION
this pr adds linting support in your local ide environment. It simply extends our root config and is used in each package that requires JS linting. 

added: 

```
 "no-unused-vars": ["error", { "ignoreRestSiblings": true }] 
```

so you can ignore properties and use spread operator when using objects/arrays