### PR TITLE
fix/allow-null-values

### DIFF
--- a/src/applications/widget-editor/src/components/filter/component.js
+++ b/src/applications/widget-editor/src/components/filter/component.js
@@ -77,9 +77,9 @@ const Filter = ({
 
   const removeFilter = useCallback((id) => {
     const patch = filters.filter(filter => filter.id !== id);
-
     setFilters({ list: patch });
-  }, [filters, setFilters]);
+    patchConfiguration();
+  }, [filters, setFilters, patchConfiguration]);
 
   return (
     <StyledFilterBox>

--- a/src/packages/core/src/filters/index.ts
+++ b/src/packages/core/src/filters/index.ts
@@ -22,7 +22,10 @@ export const getSerializedFilters = (filters: Filters.Filter[]): Filters.Seriali
   }
 
   return filters
-    .filter(filter => filter.value !== undefined && filter.value !== null)
+    .filter(filter => {
+      const hasValue = filter.value !== undefined && filter.value !== null;
+      return hasValue || filter.notNull;
+    })
     .map(filter => ({
       name: filter.column,
       type: filter.type,

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -237,7 +237,7 @@ export default class FiltersService implements Filters.Service {
 
   prepareFilters() {
     let sql = this.sql;
-    const filters = this.validateFilters(this.filters.list ?? []));
+    const filters = this.validateFilters(this.filters.list ?? []);
     const validFilters = filters.filter(f => f.valid);
 
     if (validFilters.length > 0) {

--- a/src/packages/core/src/services/filters.ts
+++ b/src/packages/core/src/services/filters.ts
@@ -1,6 +1,6 @@
 // Filter service is responsible for:
-// Formating SQL string based on properties
-// Request new data based on propertie configuration
+// Formatting SQL string based on properties
+// Request new data based on properties configuration
 import isPlainObject from "lodash/isPlainObject";
 import isArray from "lodash/isArray";
 
@@ -83,7 +83,7 @@ export default class FiltersService implements Filters.Service {
   }
 
   /**
-   * Return the serialization of the number filter as SQL (for the WHERE statement)
+   * Return the serialisation of the number filter as SQL (for the WHERE statement)
    * @param filter Number filter to serialize
    */
   private getNumberFilterQuery(filter: Filters.NumberFilter): string {
@@ -129,7 +129,7 @@ export default class FiltersService implements Filters.Service {
   }
 
   /**
-   * Return the serialization of the date filter as SQL (for the WHERE statement)
+   * Return the serialisation of the date filter as SQL (for the WHERE statement)
    * @param filter Date filter to serialize
    */
   private getDateFilterQuery(filter: Filters.DateFilter): string {
@@ -178,7 +178,7 @@ export default class FiltersService implements Filters.Service {
   }
 
   /**
-   * Return the serialization of the string filter as SQL (for the WHERE statement)
+   * Return the serialisation of the string filter as SQL (for the WHERE statement)
    * @param filter String filter to serialize
    */
   private getStringFilterQuery(filter: Filters.StringFilter): string {
@@ -219,30 +219,47 @@ export default class FiltersService implements Filters.Service {
     return sql;
   }
 
+  // We allow the filter through if "notNull" is applied to filter
+  // when calling prepareFilters, we will only apply not null operation if no value present
+  // otherwise we apply both
+  validateFilters(filters) {
+    return filters.map(filter => {
+      const hasValue = filter.value !== undefined && filter.value !== null
+        && (!Array.isArray(filter.value) || filter.value.length > 0);
+      const filterNullValues = filter.notNull;
+      return {
+        valid: hasValue || filter.notNull,
+        hasValue,
+        filter
+      }
+    });
+  }
+
   prepareFilters() {
     let sql = this.sql;
-    const validFilters = (this.filters.list ?? [])
-      .filter(filter => filter.value !== undefined && filter.value !== null
-        && (!Array.isArray(filter.value) || filter.value.length > 0));
+    const filters = this.validateFilters(this.filters.list ?? []));
+    const validFilters = filters.filter(f => f.valid);
 
     if (validFilters.length > 0) {
       sql = `${sql} WHERE `;
 
-      validFilters.forEach((filter, index) => {
+      validFilters.forEach(({ filter, hasValue }, index) => {
         const { column, type, notNull } = filter;
 
         sql = index > 0 ? `${sql} AND ` : sql;
 
-        if (type === 'number') {
-          sql = `${sql} ${this.getNumberFilterQuery(filter as Filters.NumberFilter)}`;
-        } else if (type === 'date') {
-          sql = `${sql} ${this.getDateFilterQuery(filter as Filters.DateFilter)}`;
-        } else if (type === 'string') {
-          sql = `${sql} ${this.getStringFilterQuery(filter as Filters.StringFilter)}`;
+        if (hasValue) {
+          if (type === 'number') {
+            sql = `${sql} ${this.getNumberFilterQuery(filter as Filters.NumberFilter)}`;
+          } else if (type === 'date') {
+            sql = `${sql} ${this.getDateFilterQuery(filter as Filters.DateFilter)}`;
+          } else if (type === 'string') {
+            sql = `${sql} ${this.getStringFilterQuery(filter as Filters.StringFilter)}`;
+          }
         }
 
         if (notNull) {
-          sql = `${sql} AND ${column} IS NOT NULL`;
+          sql = `${sql} ${hasValue ? 'AND' : ''} ${column} IS NOT NULL`;
         }
       });
     }
@@ -269,7 +286,7 @@ export default class FiltersService implements Filters.Service {
   prepareOrderBy() {
     const { orderBy, chartType, aggregateFunction } = this.configuration;
 
-    // If the user hasn't explicitely ordered the data, we still apply some default sorting
+    // If the user hasn't explicitly ordered the data, we still apply some default sorting
     // (which isn't shown in the UI) so the chart looks nice
     // The sorting depends on the type of the chart and the user can still override it manually
     let orderByField;
@@ -323,10 +340,10 @@ export default class FiltersService implements Filters.Service {
   }
 
   /**
-   * Return the deserialized filters allow with their configuration (values and/or minimum and
+   * Return the deserialised filters allow with their configuration (values and/or minimum and
    * maximum)
    * @param adapter Adapter
-   * @param filters Serialized filters
+   * @param filters Serialised filters
    * @param fields Dataset's fields
    * @param dataset Dataset object
    */


### PR DESCRIPTION
This pr adds the possibility to filter out "null" values if checkbox is marked, even If an operation is not present in the UI. This allows this action to be independent of the operation itself as it's not the same instruction anyway. This was reported as a bug but was intended from the initial integration.

When an operation is not present we simply skip applying it in `FiltersService.prepareFilters`. If both operation and notNull is present we apply both. 

## Testing instructions

Make sure when activating "notNull" values in your filter that it gets applied correctly. Add multiple filters to make sure the chain of commands is not broken. 

Activate multiple "notNull" operations and check that the SQL is formatted correctly. 

## Pivotal Tracker

[task](https://www.pivotaltracker.com/story/show/175278947)