### PR TITLE
fix/pie-donut-not-rendering

### DIFF
--- a/src/applications/renderer/src/components/legend/component.js
+++ b/src/applications/renderer/src/components/legend/component.js
@@ -26,10 +26,10 @@ function resolveLabel(label, type) {
 const Legend = ({
   widget,
   advanced,
-  configuration,
   scheme,
   selectedColumn,
   columns,
+  configuration,
   patchConfiguration,
   compact,
 }) => {
@@ -45,12 +45,15 @@ const Legend = ({
         type: option.type,
         alias: option.label !== option.value ? option.label : undefined,
       };
-    patchConfiguration({
-      category: newOption,
-      ...(!isPie && !isDonut && {
+    if (isPie || isDonut) {
+      patchConfiguration({
+        category: newOption
+      });
+    } else {
+      patchConfiguration({
         color: newOption
-      })
-    });
+      });
+    }
   }, [isPie, isDonut, patchConfiguration]);
 
   return (

--- a/src/applications/renderer/src/components/legend/component.js
+++ b/src/applications/renderer/src/components/legend/component.js
@@ -33,10 +33,9 @@ const Legend = ({
   patchConfiguration,
   compact,
 }) => {
+  const multipleItems = widget?.legend?.[0]?.values.length > 0;
   const isPie = configuration.chartType === "pie";
   const isDonut = configuration.chartType === "donut";
-
-  const multipleItems = widget?.legend?.[0]?.values.length > 0;
 
   const handleChange = useCallback((option) => {
     const newOption = option.value === "_single_color"
@@ -46,17 +45,12 @@ const Legend = ({
         type: option.type,
         alias: option.label !== option.value ? option.label : undefined,
       };
-
-    if (isPie || isDonut) {
-      patchConfiguration({
-        category: newOption,
+    patchConfiguration({
+      category: newOption,
+      ...(!isPie && !isDonut && {
         color: newOption
-      });
-    } else {
-      patchConfiguration({
-        category: newOption
-      });
-    }
+      })
+    });
   }, [isPie, isDonut, patchConfiguration]);
 
   return (

--- a/src/applications/renderer/src/components/legend/component.js
+++ b/src/applications/renderer/src/components/legend/component.js
@@ -34,6 +34,8 @@ const Legend = ({
   compact,
 }) => {
   const isPie = configuration.chartType === "pie";
+  const isDonut = configuration.chartType === "donut";
+
   const multipleItems = widget?.legend?.[0]?.values.length > 0;
 
   const handleChange = useCallback((option) => {
@@ -45,12 +47,17 @@ const Legend = ({
         alias: option.label !== option.value ? option.label : undefined,
       };
 
-    if (isPie) {
-      patchConfiguration({ category: newOption });
+    if (isPie || isDonut) {
+      patchConfiguration({
+        category: newOption,
+        color: newOption
+      });
     } else {
-      patchConfiguration({ color: newOption });
+      patchConfiguration({
+        category: newOption
+      });
     }
-  }, [isPie, patchConfiguration]);
+  }, [isPie, isDonut, patchConfiguration]);
 
   return (
     <StyledContainer compact={compact}>

--- a/src/applications/widget-editor/src/sagas/widget/getWidgetData.js
+++ b/src/applications/widget-editor/src/sagas/widget/getWidgetData.js
@@ -16,9 +16,9 @@ function* getWidgetDataWithAdapter(editorState) {
   };
 
   const { configuration } = editorState;
-  const { value, category, color, chartType } = configuration;
+  const { value, category } = configuration;
 
-  if (columnsSet(value, category, color, chartType)) {
+  if (columnsSet(value, category)) {
     const { widgetEditor: store } = yield select();
     const data = yield adapter.requestData(store);
     return data;

--- a/src/applications/widget-editor/src/sagas/widget/getWidgetData.js
+++ b/src/applications/widget-editor/src/sagas/widget/getWidgetData.js
@@ -9,21 +9,21 @@ import { getLocalCache } from "exposed-hooks";
 function* getWidgetDataWithAdapter(editorState) {
   const { adapter } = getLocalCache();
 
-  const columnsSet = (value, category) => {
-    return (
-      value &&
-      category &&
-      typeof value === "object" &&
-      typeof category === "object" &&
-      "name" in value &&
-      "name" in category
-    );
+  const columnsSet = (value, category, color, chartType) => {
+    const hasCategory = category && typeof category === "object" && "name" in category;
+    const hasValue = value && typeof value === "object" && "name" in value;
+    const hasColor = color && typeof color === "object" && "name" in color;
+
+    if (chartType === 'donut' || chartType === 'pie') {
+      return hasValue && hasColor;
+    }
+    return hasCategory && hasValue;
   };
 
   const { configuration } = editorState;
-  const { value, category } = configuration;
+  const { value, category, color, chartType } = configuration;
 
-  if (columnsSet(value, category)) {
+  if (columnsSet(value, category, color, chartType)) {
     const { widgetEditor: store } = yield select();
     const data = yield adapter.requestData(store);
     return data;

--- a/src/applications/widget-editor/src/sagas/widget/getWidgetData.js
+++ b/src/applications/widget-editor/src/sagas/widget/getWidgetData.js
@@ -3,20 +3,15 @@ import { getLocalCache } from "exposed-hooks";
 
 /**
  * @generator getWidgetDataWithAdapter
- * utilizing the specified adapter to request widget data
+ * utilising the specified adapter to request widget data
  * @triggers <void>
  */
 function* getWidgetDataWithAdapter(editorState) {
   const { adapter } = getLocalCache();
 
-  const columnsSet = (value, category, color, chartType) => {
+  const columnsSet = (value, category) => {
     const hasCategory = category && typeof category === "object" && "name" in category;
     const hasValue = value && typeof value === "object" && "name" in value;
-    const hasColor = color && typeof color === "object" && "name" in color;
-
-    if (chartType === 'donut' || chartType === 'pie') {
-      return hasValue && hasColor;
-    }
     return hasCategory && hasValue;
   };
 

--- a/src/packages/shared/src/modules/configuration/selectors.js
+++ b/src/packages/shared/src/modules/configuration/selectors.js
@@ -48,7 +48,7 @@ export const isMap = createSelector(
 export const selectSelectedColorOption = createSelector(
   [selectChartType, selectCategory, selectColor, selectColumnOptions],
   (chartType, category, color, columnOptions) => {
-    if (chartType === "pie") {
+    if (chartType === "pie" || chartType === "donut") {
       const colorColumn = category?.name
         ? columnOptions.find(column => column.value === category.name)
         : null;


### PR DESCRIPTION
This pr fixes issues where pie/donut chats were not rendering as expected. The underlining issue was that when selecting a color and pie or donut is selected, we need to update the category as well. otherwise, `isColumnsSet` will fail when trying to fetch resources. 

## Testing instructions

1. Without selecting anything, select pie chart then value + color, chart should appear. 
2. Repeat step1 with donut
3. Start with a non-pie/donut chart then switch to it 
4. Make sure when switching between chart types columns behave as expected

## Pivotal Tracker

[here](https://www.pivotaltracker.com/story/show/175279069)