### PR TITLE
Fix the axes titles not being serialised and deserialised

### DIFF
--- a/src/applications/renderer/src/components/chart/component.js
+++ b/src/applications/renderer/src/components/chart/component.js
@@ -235,13 +235,25 @@ class Chart extends React.Component {
         this.generateRuntime(this.verifyCustomChart(standaloneConfiguration));
       }
     } else {
+      const editedConfiguration = { ...vegaConfiguration };
+
       // XXX: Remove any nessesary information if not advanced mode
       // This is for example if:
       // 1. User deletes the entire custom configuration
       if (!advanced) {
-        delete vegaConfiguration.legends;
+        delete editedConfiguration.legends;
       }
-      this.generateRuntime(vegaConfiguration);
+
+      // If not standalone, we don't want to show the axes titles
+      editedConfiguration.axes = [...editedConfiguration.axes];
+      editedConfiguration.axes?.forEach((axis, index) => {
+        if (axis.title) {
+          editedConfiguration.axes[index] = { ...axis };
+          delete editedConfiguration.axes[index].title;
+        }
+      });
+
+      this.generateRuntime(editedConfiguration);
     }
   }
 

--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -121,13 +121,31 @@ function* preloadData() {
     const xAxis = axes?.find(axis => axis.scale === 'x');
     const yAxis = axes?.find(axis => axis.scale === 'y');
 
+    const categoryName = paramsConfig?.category?.alias ?? paramsConfig?.category?.name;
+    const valueName = paramsConfig?.value?.alias ?? paramsConfig?.value?.name;
+
+    // There are two ways an axis can get a title: either the user manually give it one, or by
+    // default, the title is the alias/name of the field the axis is based on
+    // When we're restoring a widget, we want to restore the axes text fields (the “overwrite axis
+    // title” inputs), only if the user has manually entered titles
+    // If we would always restore them, when the user would change the category or value fields, the
+    // axes titles would stay with the names of the previous fields
+    // There's no easy way to detect if the titles were set manually or automatically, apart from
+    // checking if they equal the alias/name of the fields used at serialization time
+    const xAxisTitle = xAxis?.title && (!categoryName || categoryName !== xAxis.title)
+      ? xAxis.title
+      : null;
+    const yAxisTitle = yAxis?.title && (!valueName || valueName !== yAxis.title)
+      ? yAxis.title
+      : null;
+
     const configuration = {
       ...(paramsConfig ? { ...paramsConfig } : {}),
       title: name,
       description,
       caption,
-      xAxisTitle: xAxis?.title ?? null,
-      yAxisTitle: yAxis?.title ?? null,
+      xAxisTitle,
+      yAxisTitle,
       rasterOnly,
       visualizationType: isMap ? 'map' : 'chart',
       ...(isMap ? { chartType: 'map' } : {}),

--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -118,8 +118,15 @@ function* preloadData() {
     }
 
     const { axes } = widgetConfig;
-    const xAxis = axes?.find(axis => axis.scale === 'x');
-    const yAxis = axes?.find(axis => axis.scale === 'y');
+
+    // The horizontal bar charts have their axes inverted: the one named 'x' is based on the value
+    // and the one named 'y' is based on the category
+    const chartsWithInversedAxes = ['bar-horizontal', 'stacked-bar-horizontal'];
+    const xAxisName = chartsWithInversedAxes.includes(paramsConfig?.chartType) ? 'y' : 'x';
+    const yAxisName = chartsWithInversedAxes.includes(paramsConfig?.chartType) ? 'x' : 'y';
+
+    const xAxis = axes?.find(axis => axis.scale === xAxisName);
+    const yAxis = axes?.find(axis => axis.scale === yAxisName);
 
     const categoryName = paramsConfig?.category?.alias ?? paramsConfig?.category?.name;
     const valueName = paramsConfig?.value?.alias ?? paramsConfig?.value?.name;

--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -117,11 +117,17 @@ function* preloadData() {
       paramsConfig.aggregateFunction = null;
     }
 
+    const { axes } = widgetConfig;
+    const xAxis = axes?.find(axis => axis.scale === 'x');
+    const yAxis = axes?.find(axis => axis.scale === 'y');
+
     const configuration = {
       ...(paramsConfig ? { ...paramsConfig } : {}),
       title: name,
       description,
       caption,
+      xAxisTitle: xAxis?.title ?? null,
+      yAxisTitle: yAxis?.title ?? null,
       rasterOnly,
       visualizationType: isMap ? 'map' : 'chart',
       ...(isMap ? { chartType: 'map' } : {}),

--- a/src/packages/core/src/charts/bars-grouped-horizontal.ts
+++ b/src/packages/core/src/charts/bars-grouped-horizontal.ts
@@ -68,6 +68,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
         format: this.resolveFormat('y'),
         grid: true,
         labelOverlap: "parity",
+        title: this.resolveTitle('y'),
         encode: {
           labels: {
             update: {
@@ -88,6 +89,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
         // If it doesn't the chart might not be displayed at all due to this bug:
         // https://github.com/vega/vega/issues/1350
         titleLimit: { "signal": "height" },
+        title: this.resolveTitle('x'),
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/bars-grouped.ts
+++ b/src/packages/core/src/charts/bars-grouped.ts
@@ -151,6 +151,7 @@ export default class GroupedBars extends ChartsCommon implements Charts.Bars {
         scale: "x",
         labelOverlap: "parity",
         ticks: false,
+        title: this.resolveTitle('x'),
         encode: {
           labels: {
             update: {
@@ -183,6 +184,7 @@ export default class GroupedBars extends ChartsCommon implements Charts.Bars {
         // If it doesn't the chart might not be displayed at all due to this bug:
         // https://github.com/vega/vega/issues/1350
         titleLimit: { "signal": "height" },
+        title: this.resolveTitle('y'),
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/bars-horizontal.ts
+++ b/src/packages/core/src/charts/bars-horizontal.ts
@@ -57,6 +57,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
         format: this.resolveFormat('y'),
         grid: true,
         labelOverlap: "parity",
+        title: this.resolveTitle('y'),
       },
       {
         orient: "left",
@@ -69,6 +70,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
         // If it doesn't the chart might not be displayed at all due to this bug:
         // https://github.com/vega/vega/issues/1350
         titleLimit: { "signal": "height" },
+        title: this.resolveTitle('x'),
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/bars-stacked-horizontal.ts
+++ b/src/packages/core/src/charts/bars-stacked-horizontal.ts
@@ -68,6 +68,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
         format: this.resolveFormat('y'),
         grid: true,
         labelOverlap: "parity",
+        title: this.resolveTitle('y'),
         encode: {
           labels: {
             update: {
@@ -88,6 +89,7 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
         // If it doesn't the chart might not be displayed at all due to this bug:
         // https://github.com/vega/vega/issues/1350
         titleLimit: { "signal": "height" },
+        title: this.resolveTitle('x'),
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/bars-stacked.ts
+++ b/src/packages/core/src/charts/bars-stacked.ts
@@ -120,6 +120,7 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
         scale: "x",
         labelOverlap: "parity",
         ticks: false,
+        title: this.resolveTitle('x'),
         encode: {
           labels: {
             update: {
@@ -152,6 +153,7 @@ export default class BarsStacked extends ChartsCommon implements Charts.Bars {
         // If it doesn't the chart might not be displayed at all due to this bug:
         // https://github.com/vega/vega/issues/1350
         titleLimit: { "signal": "height" },
+        title: this.resolveTitle('y'),
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/bars.ts
+++ b/src/packages/core/src/charts/bars.ts
@@ -106,6 +106,7 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
         scale: "x",
         labelOverlap: "parity",
         ticks: false,
+        title: this.resolveTitle('x'),
         encode: {
           labels: {
             update: {
@@ -138,6 +139,7 @@ export default class Bars extends ChartsCommon implements Charts.Bars {
         // If it doesn't the chart might not be displayed at all due to this bug:
         // https://github.com/vega/vega/issues/1350
         titleLimit: { "signal": "height" },
+        title: this.resolveTitle('y'),
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/chart-common.ts
+++ b/src/packages/core/src/charts/chart-common.ts
@@ -16,7 +16,7 @@ export default class ChartCommon {
     return configuration.category?.type === 'date';
   }
 
-  resolveName(axis: 'x' | 'y' | 'color') {
+  resolveName(axis: 'x' | 'y' | 'color'): string {
     const { configuration, editor } = this.store;
     const { xAxisTitle, yAxisTitle } = configuration;
 
@@ -49,6 +49,14 @@ export default class ChartCommon {
     }
 
     return name;
+  }
+
+  /**
+   * Return the title of an axis
+   * @param axis Type of axis
+   */
+  resolveTitle(axis: 'x' | 'y'): string {
+    return this.resolveName(axis);
   }
 
   resolveFormat(axis: 'x' | 'y') {

--- a/src/packages/core/src/charts/line-multi.ts
+++ b/src/packages/core/src/charts/line-multi.ts
@@ -208,6 +208,7 @@ export default class MultiLine extends ChartsCommon implements Charts.Line {
       {
         orient: "bottom",
         scale: "x",
+        title: this.resolveTitle('x'),
         ...(this.isDate() ? {
           encode: {
             labels: {
@@ -231,6 +232,7 @@ export default class MultiLine extends ChartsCommon implements Charts.Line {
         // If it doesn't the chart might not be displayed at all due to this bug:
         // https://github.com/vega/vega/issues/1350
         titleLimit: { "signal": "height" },
+        title: this.resolveTitle('y'),
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/line.ts
+++ b/src/packages/core/src/charts/line.ts
@@ -181,6 +181,7 @@ export default class Line extends ChartsCommon implements Charts.Line {
       {
         orient: "bottom",
         scale: "x",
+        title: this.resolveTitle('x'),
         ...(this.isDate() ? {
           encode: {
             labels: {
@@ -204,6 +205,7 @@ export default class Line extends ChartsCommon implements Charts.Line {
         // If it doesn't the chart might not be displayed at all due to this bug:
         // https://github.com/vega/vega/issues/1350
         titleLimit: { "signal": "height" },
+        title: this.resolveTitle('y'),
         encode: {
           labels: {
             update: {

--- a/src/packages/core/src/charts/scatter.ts
+++ b/src/packages/core/src/charts/scatter.ts
@@ -159,6 +159,7 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
         "scale": "x",
         "labelOverlap": "parity",
         "orient": "bottom",
+        title: this.resolveTitle('x'),
         "encode": {
           "labels": {
             "update": {
@@ -186,6 +187,7 @@ export default class Scatter extends ChartsCommon implements Charts.Scatter {
         // If it doesn't the chart might not be displayed at all due to this bug:
         // https://github.com/vega/vega/issues/1350
         titleLimit: { "signal": "height" },
+        title: this.resolveTitle('y'),
       }
     ]
   }


### PR DESCRIPTION
This PR fixes issues related to the serialisation and deserialisation of the chart's axes titles.

Here's the complete list of issues this PR addresses:
- If the user would manually set axes titles, they would not be serialised
- If the user would save a widget without custom (manual) axes titles, the alias/name of the fields would not be serialised as default axes titles
- In the renderer, the axes titles would not be displayed
- In the editor, the axes titles would not be deserialised (restored)

Unfortunately, because these issues were located in the serialisation/deserialisation process, all the widgets created with v2 are not displaying axes titles and won't either with this fix. They need to be re-serialised (saved again through the editor) or migrated with the migration script.

Note that v1 was not using the alias/name of the fields as default axes titles either, but the UI being different in v2, it conveyed the idea that the aliases/names would be automatically set as titles.

## Testing instructions

1. Restore the widget https://api.resourcewatch.org/v1/widget/e7d822f5-3039-4593-822a-5b92d7fa72f2

This widget was serialised without axes titles (v2.5.0).

2. Click the “Get Editor State” of the playground

Make sure the category and value fields are used as axes titles: check the the `payload.axes[].title` properties.

3. Switch to the Renderer view

Make sure axes titles are displayed.

4. Go back to the editor view

Make sure Vega doesn't render the axes titles within the visualisation.

5. Restore the widget https://api.resourcewatch.org/v1/widget/62835ee8-606e-4157-806f-a38b33155d8f

This widget was created with v1 and contains custom (manual) axes titles.

Make sure axes titles appear in the “Value” and “Category” text inputs of the “Description and labels” accordion settings. These inputs are the ones used to overwrite the axes titles.

6. Switch to the Renderer view

Make sure the axes titles are displayed in the visualisation.

7. Restore the widget https://api.resourcewatch.org/v1/widget/b28ef310-0368-44e8-9aab-3f08b2fe2ab2

This widget was created with the changes of this PR. It contains default axes titles − axes titles based on the category and value fields.

Make sure these titles don't appear in the “Value” and “Category” text inputs of the “Description and labels” accordion settings.

8. Switch to the Renderer view

Make sure the axes titles are displayed in the visualisation.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175788641)
