### PR TITLE
Fix an issue updating the default geo filter dynamically

### DIFF
--- a/src/applications/widget-editor/README.md
+++ b/src/applications/widget-editor/README.md
@@ -60,6 +60,8 @@ This property allows you to disable specific features in the editor, read more h
 
 When `areaIntersection` is set, it is used as a default geographic filter for the dataset/widget. Even if the widget already has a geographic filter, it will be overwritten by the value of `areaIntersection`. Yet, the user will still be able to change the geographic filter in the UI.
 
+If the `areaIntersection` prop is later removed, the widget-editor will remove the geographic filter instead of restoring the widget's original filter value.
+
 If the `areaIntersection` is a user's area, the widget-editor's adapter must receive the user's token as `userToken` in order to correctly display the name of the area, otherwise, it will be shown as “Custom area”.
 
 If the dataset doesn't provide geographic information, this property is ignored.

--- a/src/applications/widget-editor/src/components/editor/index.js
+++ b/src/applications/widget-editor/src/components/editor/index.js
@@ -28,7 +28,8 @@ export default connectState(
     configuration: state.configuration,
     widget: state.widgetConfig,
     editorState: state,
-    hasGeoInfo: selectHasGeoInfo(state)
+    hasGeoInfo: selectHasGeoInfo(state),
+    initialized: state.editor.initialized,
   }),
   dispatch => {
     return {


### PR DESCRIPTION
This PR fixes an issue where the host app wouldn't be able to dynamically set a default geographic filter.

The issue was mainly caused by a race condition between the constructor and the `componentDidUpdate` function of the `Editor` component.

Multiple comments have been added to the code to explain the changes and avoid these issues to come back.

## Testing instructions

This PR was tested by manually copying the compiled editor code to RW's `node_modules` folder and restarting RW's server.

Nevertheless, it can be replicated by quickly updating the `areaIntersection` prop from a falsy value to a valid string. This needs to be quick enough so `componentDidMount` is called before `resolveAreaIntersection` is called in the constructor.

If you wish to test it within RW, here is what you need to do:
1. Execute `yarn build` in this branch
2. Copy the folder `src/applications/widget-editor/lib`
3. Clone [RW](https://github.com/resource-watch/resource-watch/) and pull the `develop` branch
4. Replace `resource-watch/node_modules/@widget-editor/widget-editor/lib` by the folder you previously copied
5. Start RW's server: `yarn dev`
6. Open `localhost:5000/data/explore`
7. Click “Areas of Interest” and log in
8. Click “Show Area” of one of your custom areas (you need to create one if you don't have any)
9. Click “All Data” and click the first dataset: “Global Power Plant Database”
10. Scroll down to the editor

Make sure the geographic filter is set to your area.

Additionally, in the playground, test that the “Area Intersection” setting still works fine by switching between these values: `01dec423bd8a15a0ad8756f72d1f0788` (Argentina) and `35a6d982388ee5c4e141c2bceac3fb72` (Spain).

## Pivotal Tracker

Not tracked. Reported by Andrés on Slack.
