### PR TITLE
Fix a crash that could occur when rendering maps

### DIFF
--- a/src/applications/renderer/src/components/standalone/component.js
+++ b/src/applications/renderer/src/components/standalone/component.js
@@ -81,7 +81,7 @@ const Standalone = ({
               basemap: widgetConfig.basemapLayers || null,
             }}
             caption={widgetName}
-            layers={[layerData]}
+            layers={layerData ? [layerData] : []}
             changeBbox={changeBbox}
             interactionEnabled={interactionEnabled}
           />

--- a/src/applications/renderer/src/components/standalone/fetch-layers-hook.js
+++ b/src/applications/renderer/src/components/standalone/fetch-layers-hook.js
@@ -3,7 +3,9 @@ import { useState, useEffect, useMemo } from "react";
 const useLayerData = (adapter, layerId, isMap) => {
   const [layerData, setData] = useState(null);
 
-  const [isLoadingLayers, setIsLoading] = useState(false);
+  // We set the default state to loading so that this hook never returns null on initialization
+  const [isLoadingLayers, setIsLoading] = useState(true);
+
   const [isErrorLayers, setIsError] = useState(false);
 
   const adapterInstance = useMemo(() => new adapter(), [adapter]);


### PR DESCRIPTION
This PR fixes an issue where the Renderer could crash when rendering map widgets. The layer-manager helper would receive a `null` layer when initialising.

## Testing instructions

This can't be directly replicated in the playground as the layer is fetched very quickly and the initial `null` state is quickly replaced. Nonetheless, the bug can be triggered in [Earth Dashboard](https://github.com/wri/earth-dashboard) in the page `/climate/data` when switching between a desktop and mobile screen size.

## Pivotal Tracker

Not tracked. Reported by Pablo on Slack.
