### PR TITLE
Fix an eventual crash when changing the operation of date filter

### DIFF
--- a/src/packages/core/src/filters/index.ts
+++ b/src/packages/core/src/filters/index.ts
@@ -19,18 +19,19 @@ export const getSerializedFilters = (filters: Filters.Filter[]): Filters.Seriali
     }
 
     return value;
-  }
+  };
+
+  const hasValue = ({ value }) => value !== undefined && value !== null;
 
   return filters
-    .filter(filter => {
-      const hasValue = filter.value !== undefined && filter.value !== null;
-      return hasValue || filter.notNull;
-    })
+    .filter(filter => hasValue(filter) || filter.notNull)
     .map(filter => ({
       name: filter.column,
       type: filter.type,
       operation: filter.operation,
-      value: getSerializedValue(filter),
+      value: hasValue(filter)
+        ? getSerializedValue(filter)
+        : null,
       notNull: filter.notNull,
     }));
 };


### PR DESCRIPTION
This PR fixes an issue where the editor would crash when changing the operation of a date filter if its not null setting would be checked.

This is a regression from #158. We did not take into account that when the not null setting is checked, we would try to serialise a null value as if it was a date.

## Testing instructions

1. Restore the following widget: `https://api.resourcewatch.org/v1/widget/d4f32fb9-9cc9-44b3-9abd-72ae78b43921`
2. For the filter based on the “Year” field, change the operation to “Greater than”

Make sure the that:
- the editor didn't crash (no error related to serialisation in the console)
- the request to get the widget's data includes `datetime IS NOT NULL` in its where clause (no other filter should be applied to `datetime`)

3. Set the filter's value to 01/01/1992

Make sure the filter is correctly applied by looking at the request to get the data.

4. Change the operation to “Less than” (the value will be removed)
5. Uncheck “Remove "null" values”

Make sure the editor doesn't crash and that the request doesn't include anything about `datetime` in its where clause.

## Pivotal Tracker

Not tracked.
