### PR TITLE
Fix bug that prevented Vega widgets from rendering in the Renderer

### DIFF
--- a/src/applications/renderer/src/components/standalone/fetch-layers-hook.js
+++ b/src/applications/renderer/src/components/standalone/fetch-layers-hook.js
@@ -3,8 +3,7 @@ import { useState, useEffect, useMemo } from "react";
 const useLayerData = (adapter, layerId, isMap) => {
   const [layerData, setData] = useState(null);
 
-  // We set the default state to loading so that this hook never returns null on initialization
-  const [isLoadingLayers, setIsLoading] = useState(true);
+  const [isLoadingLayers, setIsLoading] = useState(false);
 
   const [isErrorLayers, setIsError] = useState(false);
 


### PR DESCRIPTION
PR #168 introduced a regression where the Vega widgets would not be rendered anymore in the Renderer. This PR addresses this issue.

PR #168 sets the default state of the layers as loading, but since Vega widgets don't load the layers, the Renderer would get stuck in the loading state. To fix the regression, the default state has been brought back to not loading. The original issue of #168 is still addressed because two checks were added.

## Testing instructions

1. Open any Vega widget in the Renderer

You should see it.

2. Open any map widget in the Renderer

You should also see it.

3. Follow the testing instructions of #168

## Pivotal Tracker

Not tracked. Reported by Pablo on Slack.
