### PR TITLE
Fix bugs with the map serialisation and deserialisation

### DIFF
--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -61,7 +61,7 @@ function* preloadData() {
     const mapSpecifics = {
       ...storeConfiguration.map,
       ...(has(widgetConfig, 'lat') ? { lat: widgetConfig.lat } : {}),
-      ...(has(widgetConfig, 'lng') ? { lat: widgetConfig.lng } : {}),
+      ...(has(widgetConfig, 'lng') ? { lng: widgetConfig.lng } : {}),
       ...(has(widgetConfig, 'bbox') ? { bbox: widgetConfig.bbox } : {}),
       ...(has(widgetConfig, 'basemapLayers')
         ? {

--- a/src/packages/map/src/index.js
+++ b/src/packages/map/src/index.js
@@ -272,6 +272,10 @@ class Map extends React.Component {
     }
 
     this.map.setZoom(mapOptions.zoom);
+
+    // We save the initial state of the map so if the user saves a restored widget without making
+    // any change, we save the correct info
+    this.onMapChange();
   }
 
   instantiateLayerManager() {

--- a/src/packages/map/src/index.js
+++ b/src/packages/map/src/index.js
@@ -251,16 +251,17 @@ class Map extends React.Component {
       this.props.mapConfiguration?.basemap?.boundaries || false
     );
 
-    // In version2 of the editor we are storing the bbox
+    // In version 2 of the editor we are storing the bbox
     // This is so in the future we can migrate to for example mapbox
     // If we have a BBOX, this is automatically saved in the new editor
     // We pan to it if present
+    // NOTE: the bbox format is still Leaflet's
     if (mapOptions.bbox && Array.isArray(mapOptions.bbox)) {
-      const [b0, b1, b2, b3] = mapOptions.bbox;
+      const [SWLat, SWLon, NELat, NELon] = mapOptions.bbox;
       this.map.fitBounds(
         [
-          [b1, b0],
-          [b3, b2]
+          [SWLat, SWLon],
+          [NELat, NELon]
         ],
         { animate: false }
       );


### PR DESCRIPTION
This PR fixes 3 bugs affecting the serialisation and deserialisation of the map widgets:
- The longitude of the map's center wouldn't be deserialised correctly
- The map's bbox wouldn't be restored correctly
- Saving a restored map widget without making any change would save a wrong configuration

## Testing instructions

1. Restore this widget: `https://api.resourcewatch.org/v1/widget/6949dfc4-91ad-46b3-bdc3-d6e7e82d41fb`

The map must be centred on the US.

2. Save the widget without making any change

Make sure the centre is the same as the original widget and that the bounds are similar. The bounds are not 100% the same probably because the widget was saved with an editor that had a different size.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/176124879).
