### PR TITLE
Memoise the adapter's instances

### DIFF
--- a/src/applications/renderer/src/components/renderer/component.js
+++ b/src/applications/renderer/src/components/renderer/component.js
@@ -18,6 +18,8 @@ const Renderer = ({
     throw new Error("Renderer: Missing prop adapter and adapter needs to be of type Adapter");
   }
 
+  const adapterInstance = useMemo(() => new adapter(), [adapter]);
+
   const isMap = widgetConfig?.paramsConfig?.visualizationType === "map";
   const { layerData, isLoadingLayers, isErrorLayers } = useLayerData(
     adapter,
@@ -67,7 +69,7 @@ const Renderer = ({
       {isMap && (
         <Suspense>
           <Map
-            adapter={new adapter()}
+            adapter={adapterInstance}
             layerId={widgetConfig.paramsConfig?.layer}
             thumbnail={thumbnail}
             mapConfiguration={{

--- a/src/applications/widget-editor/src/components/visualization/component.js
+++ b/src/applications/widget-editor/src/components/visualization/component.js
@@ -32,6 +32,8 @@ const Visualization = ({
 
   const isMap = configuration.visualizationType === "map";
 
+  const adapterInstance = useMemo(() => new adapter(), [adapter]);
+
   const chartDataAvailable = useMemo(
     () => advanced || (widgetData && widgetData.length > 0),
     [advanced, widgetData],
@@ -102,7 +104,7 @@ const Visualization = ({
         <StyledMapContainer>
           {!!configuration.title && <StyledMapTitle>{configuration.title}</StyledMapTitle>}
           <Map
-            adapter={new adapter()}
+            adapter={adapterInstance}
             layerId={configuration.layer}
             layers={editor.layers}
             mapConfiguration={configuration.map}

--- a/src/applications/widget-editor/src/components/widget-editor/component.js
+++ b/src/applications/widget-editor/src/components/widget-editor/component.js
@@ -1,51 +1,49 @@
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import Editor from "components/editor";
 
-class WidgetEditor extends React.Component {
-  render() {
-    const {
-      application,
-      onSave,
-      datasetId,
-      widgetId = null,
-      adapter,
-      theme,
-      disable,
-      enableSave,
-      schemes,
-      compact = false,
-      areaIntersection,
-    } = this.props;
-
-    if (typeof adapter !== "function") {
-      throw new Error(
-        "Widget editor: Missing prop adapter and adapter needs to be of type Adapter"
-      );
-    }
-
-    if (!datasetId) {
-      throw new Error("Widget editor: Missing prop datasetId of type string");
-    }
-
-    return (
-      <Editor
-        disable={disable}
-        application={application}
-        onSave={onSave}
-        enableSave={enableSave}
-        datasetId={datasetId}
-        widgetId={widgetId}
-        areaIntersection={areaIntersection}
-        adapter={adapter}
-        adapterInstance={new adapter()}
-        schemes={schemes}
-        userPassedCompact={compact}
-        userPassedTheme={theme}
-      />
+const WidgetEditor = ({
+  application,
+  onSave,
+  datasetId,
+  widgetId = null,
+  adapter,
+  theme,
+  disable,
+  enableSave,
+  schemes,
+  compact = false,
+  areaIntersection,
+}) => {
+  if (typeof adapter !== "function") {
+    throw new Error(
+      "Widget editor: Missing prop adapter and adapter needs to be of type Adapter"
     );
   }
-}
+
+  if (!datasetId) {
+    throw new Error("Widget editor: Missing prop datasetId of type string");
+  }
+
+  const adapterInstance = useMemo(() => new adapter(), [adapter]);
+
+  return (
+    <Editor
+      disable={disable}
+      application={application}
+      onSave={onSave}
+      enableSave={enableSave}
+      datasetId={datasetId}
+      widgetId={widgetId}
+      areaIntersection={areaIntersection}
+      adapter={adapter}
+      adapterInstance={adapterInstance}
+      schemes={schemes}
+      userPassedCompact={compact}
+      userPassedTheme={theme}
+    />
+  );
+};
 
 WidgetEditor.propTypes = {
   application: PropTypes.string,


### PR DESCRIPTION
This PR adds memoisation of the adapter's instance to avoid possible useless re-renders. This change was suggested by Andrés (see task).

## Testing instructions

Make sure you can still create chart and map widgets, and display them with the adapter.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/175803428).
