### PR TITLE
feat/playground-compact

### DIFF
--- a/src/applications/widget-editor/src/components/editor/component.js
+++ b/src/applications/widget-editor/src/components/editor/component.js
@@ -94,7 +94,8 @@ class Editor extends React.Component {
       widgetId: prevWidgetId,
       userPassedTheme: prevUserPassedTheme,
       schemes: prevSchemes,
-      areaIntersection: prevAreaIntersection
+      areaIntersection: prevAreaIntersection,
+      userPassedCompact: prevUserPassedCompact
     } = prevProps;
     const {
       datasetId,
@@ -103,6 +104,7 @@ class Editor extends React.Component {
       schemes,
       areaIntersection,
       initialized,
+      userPassedCompact
     } = this.props;
 
     // When datasetId changes, we need to restore the editor itself
@@ -120,7 +122,8 @@ class Editor extends React.Component {
       this.resolveAreaIntersection(areaIntersection);
     }
 
-    if (!isEqual(userPassedTheme, prevUserPassedTheme)) {
+    if (!isEqual(userPassedTheme, prevUserPassedTheme) ||
+      !isEqual(userPassedCompact, prevUserPassedCompact)) {
       this.resolveTheme(userPassedTheme);
     }
 

--- a/src/playground/widget-editor/src/components/header.js
+++ b/src/playground/widget-editor/src/components/header.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux'
 
-import { RiLoginBoxLine, RiMistLine, RiPaletteLine } from 'react-icons/ri';
+import { RiLoginBoxLine, RiMistLine, RiPaletteLine, RiArtboard2Fill } from 'react-icons/ri';
 
 import DebugOption from "components/debug-options";
 
@@ -13,6 +13,7 @@ const modifyOptions = payload => ({
 const Header = () => {
   const dispatch = useDispatch();
   const renderer = useSelector(state => state.editorOptions.renderer);
+  const compactMode = useSelector(state => state.editorOptions.compactMode);
   const unmounted = useSelector(state => state.editorOptions.unmounted);
 
   return (
@@ -22,6 +23,13 @@ const Header = () => {
         <button type="button" onClick={() => dispatch(modifyOptions({ renderer: !renderer }))}>
           {renderer ? <RiMistLine /> : <RiPaletteLine /> } {renderer ? "View editor" : "View renderer"}
         </button>
+        {!renderer && (
+          <button
+            type="button"
+            onClick={() => dispatch(modifyOptions({ compactMode: !compactMode }))}>
+            <RiArtboard2Fill /> Compact mode {compactMode ? 'On' : 'Off'}
+          </button>
+        )}
         <button type="button" onClick={() => dispatch(modifyOptions({ unmounted: !unmounted }))}>
           <RiLoginBoxLine />
           {unmounted && 'Mount editor'}


### PR DESCRIPTION
Adds button to toggle compact mode within the playground.

## Testing instructions

Ensure compact mode works as expected on playground. It should only fiddle with the layout. Also had to add it to componentDidUpdate editor logic, so make sure this is not screwing with our optimization. 
