### PR TITLE
Fix regressions that would crash the editor when using raster datasets

### DIFF
--- a/src/adapters/rw-adapter/__tests__/__snapshots__/rw-adapter.test.ts.snap
+++ b/src/adapters/rw-adapter/__tests__/__snapshots__/rw-adapter.test.ts.snap
@@ -79,6 +79,7 @@ Object {
     "gross_value_added_contribution_to_gdp",
   ],
   "tableName": "for_020_forest_employment_gdp_edit",
+  "type": "tabular",
 }
 `;
 

--- a/src/adapters/rw-adapter/src/index.ts
+++ b/src/adapters/rw-adapter/src/index.ts
@@ -49,6 +49,7 @@ export default class RWAdapter implements Adapter.Service {
       name: dataset.attributes.name,
       tableName: dataset.attributes.tableName,
       provider: dataset.attributes.provider,
+      type: dataset.attributes.type === 'tabular' ? 'tabular' : 'raster',
       geoInfo: dataset.attributes.geoInfo,
       relevantFields: dataset.attributes.widgetRelevantProps,
       metadata: {

--- a/src/adapters/rw-adapter/src/types.ts
+++ b/src/adapters/rw-adapter/src/types.ts
@@ -7,6 +7,7 @@ export type APIDatasetPayload = {
       name: string,
       tableName: string,
       provider: string,
+      type: string,
       geoInfo: boolean,
       widgetRelevantProps: string[],
       metadata: {

--- a/src/applications/widget-editor/src/components/editor-options/index.js
+++ b/src/applications/widget-editor/src/components/editor-options/index.js
@@ -5,6 +5,7 @@ import {
   selectDisabledFeatures,
   selectAdvanced,
   selectHasGeoInfo,
+  selectDatasetIsRaster,
 } from "@widget-editor/shared/lib/modules/editor/selectors";
 
 import EditorOptionsComponent from "./component";
@@ -15,7 +16,7 @@ export default connectState(
     advanced: selectAdvanced(state),
     initialized: state.editor.initialized,
     restoring: state.editor.restoring,
-    rasterOnly: state.configuration.rasterOnly,
+    rasterOnly: selectDatasetIsRaster(state),
     datasetId:
       state.editor.dataset && state.editor.dataset.id
         ? state.editor.dataset.id

--- a/src/applications/widget-editor/src/components/select-chart/index.js
+++ b/src/applications/widget-editor/src/components/select-chart/index.js
@@ -2,7 +2,10 @@ import { redux } from "@widget-editor/shared";
 
 import { patchConfiguration } from "@widget-editor/shared/lib/modules/configuration/actions";
 import { setTheme } from "@widget-editor/shared/lib/modules/theme/actions";
-import { selectChartOptions } from "@widget-editor/shared/lib/modules/configuration/selectors";
+import {
+  selectChartOptions,
+  selectChartType,
+} from "@widget-editor/shared/lib/modules/configuration/selectors";
 
 // Components
 import SelectChartComponent from "./component";
@@ -10,7 +13,7 @@ import SelectChartComponent from "./component";
 export default redux.connectState(
   (state) => ({
     options: selectChartOptions(state),
-    chartType: state.configuration.chartType,
+    chartType: selectChartType(state),
     theme: state.theme,
   }),
   { patchConfiguration, setTheme }

--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -174,6 +174,18 @@ function* preloadData() {
     }
 
     yield put(setConfiguration({ ...configuration, format }));
+  } else if (editor.dataset) {
+    // If the editor is restored with a dataset only (no widget)
+    const { dataset: { type } } = editor;
+
+    const isRaster = type === 'raster';
+
+    yield put(setConfiguration({
+      ...storeConfiguration,
+      // We make sure to switch to the map visualization if the dataset is a raster
+      chartType: isRaster ? 'map' : storeConfiguration.chartType,
+      visualizationType: isRaster ? 'map': storeConfiguration.visualizationType,
+    }));
   }
 }
 

--- a/src/applications/widget-editor/src/sagas/editor/index.js
+++ b/src/applications/widget-editor/src/sagas/editor/index.js
@@ -51,9 +51,10 @@ function* preloadData() {
     widgetEditor: { editor, configuration: storeConfiguration }
   } = yield select();
 
-  if (editor.widget) {
+  if (editor.dataset && editor.widget) {
     const {
-      widget: { name, metadata, description, widgetConfig }
+      widget: { name, metadata, description, widgetConfig },
+      dataset: { type },
     } = editor;
 
     const mapSpecifics = {
@@ -94,11 +95,8 @@ function* preloadData() {
 
     const caption = metadata?.caption ?? '';
 
-    const datasetType = editor?.dataset?.attributes?.type;
-    const rasterOnly = !!(datasetType && datasetType.match(/raster/));
-
     // If the dataset is raster, only maps can be done right now
-    const isMap = rasterOnly
+    const isMap = type === 'raster'
       || editor?.widget?.widgetConfig?.paramsConfig?.visualizationType === 'map';
 
     const paramsConfig = has(widgetConfig, 'paramsConfig')
@@ -155,7 +153,6 @@ function* preloadData() {
       caption,
       xAxisTitle,
       yAxisTitle,
-      rasterOnly,
       visualizationType: isMap ? 'map' : 'chart',
       ...(isMap ? { chartType: 'map' } : {}),
       map: mapSpecifics

--- a/src/packages/core/__tests__/state-proxy/mock.ts
+++ b/src/packages/core/__tests__/state-proxy/mock.ts
@@ -11,7 +11,6 @@ export const BASE_STATE = {
     caption: "",
     format: "",
     visualizationType: "chart",
-    rasterOnly: false,
     chartType: "bar",
     sliceCount: 6,
     donutRadius: 100,

--- a/src/packages/core/src/services/data.ts
+++ b/src/packages/core/src/services/data.ts
@@ -184,12 +184,13 @@ export default class DataService {
   }
 
   async getFieldsAndLayers() {
-    const fields = await this.adapter.getDatasetFields(this.datasetId, this.dataset);
     const layers = await this.adapter.getDatasetLayers(this.datasetId);
-    this.fields = fields;
+    this.fields = this.dataset.type === 'raster'
+      ? []
+      : await this.adapter.getDatasetFields(this.datasetId, this.dataset);
 
     this.dispatch({ type: sagaEvents.DATA_FLOW_FIELDS_AND_LAYERS_READY });
-    this.setEditor({ layers, fields });
+    this.setEditor({ layers, fields: this.fields });
   }
 
   async requestWithFilters(store: any) {

--- a/src/packages/map/src/helpers/layer-manager.js
+++ b/src/packages/map/src/helpers/layer-manager.js
@@ -85,13 +85,13 @@ export default class LayerManager {
   }
 
   addNexGDDPLayer(layerData) {
-    const tileUrl = { layerData };
+    const { tileUrl } = layerData;
     const tileLayer = L.tileLayer(tileUrl).addTo(this.map);
     this.mapLayers[layerData.id] = tileLayer;
   }
 
   addGeeLayer(layerData) {
-    const tileUrl = { layerData };
+    const { tileUrl } = layerData;
     const tileLayer = L.tileLayer(tileUrl).addTo(this.map);
     this.mapLayers[layerData.id] = tileLayer;
   }

--- a/src/packages/shared/src/modules/configuration/initial-state.js
+++ b/src/packages/shared/src/modules/configuration/initial-state.js
@@ -4,7 +4,6 @@ export default {
   caption: "",
   format: "",
   visualizationType: "chart",
-  rasterOnly: false,
   chartType: "bar",
   sliceCount: 6,
   donutRadius: 100,

--- a/src/packages/shared/src/modules/configuration/initial-state.js
+++ b/src/packages/shared/src/modules/configuration/initial-state.js
@@ -13,7 +13,11 @@ export default {
     lat: 0,
     lng: 0,
     bbox: null,
-    basemap: null,
+    basemap: {
+      basemap: 'dark',
+      labels: 'light',
+      boundaries: false,
+    },
   },
   xAxisTitle: null,
   yAxisTitle: null,

--- a/src/packages/shared/src/modules/configuration/selectors.js
+++ b/src/packages/shared/src/modules/configuration/selectors.js
@@ -1,9 +1,12 @@
 import { createSelector } from "reselect";
 
-import { selectDisabledFeatures, selectColumnOptions } from "../editor/selectors";
+import {
+  selectDisabledFeatures,
+  selectColumnOptions,
+  selectDatasetIsRaster,
+} from "../editor/selectors";
 
 const selectAvailableCharts = state => state.configuration.availableCharts;
-const selectRasterOnly = state => state.configuration.rasterOnly;
 export const selectTitle = state => state.configuration.title;
 export const selectDescription = state => state.configuration.description;
 export const selectVisualizationType = state => state.configuration.visualizationType;
@@ -23,7 +26,7 @@ export const selectLayer = state => state.configuration.layer;
 export const selectCaption = state => state.configuration.caption;
 
 export const selectChartOptions = createSelector(
-  [selectAvailableCharts, selectRasterOnly, selectDisabledFeatures],
+  [selectAvailableCharts, selectDatasetIsRaster, selectDisabledFeatures],
   (availableCharts, isRaster, disabledFeatures) => {
     let res = availableCharts;
 

--- a/src/packages/shared/src/modules/editor/selectors.js
+++ b/src/packages/shared/src/modules/editor/selectors.js
@@ -22,6 +22,11 @@ export const selectFields = state => state.editor.fields;
 export const selectWidgetData = state => state.editor.widgetData;
 export const selectTableData = state => state.editor.tableData;
 
+export const selectDatasetIsRaster = createSelector(
+  [selectDataset],
+  dataset => dataset?.type === 'raster'
+);
+
 export const selectColumnOptions = createSelector(
   [selectFields],
   (fields) => {

--- a/src/packages/types/src/dataset.ts
+++ b/src/packages/types/src/dataset.ts
@@ -5,6 +5,8 @@ export interface Payload {
   name: string;
   tableName: string;
   provider: string;
+  /** When type is raster, the core doesn't call the adapter's getDatasetFields */
+  type: 'tabular' | 'raster';
   geoInfo: boolean;
   relevantFields: string[];
   metadata: {


### PR DESCRIPTION
This PR fixes two regressions that would crash the widget-editor when restoring a dataset or a widget based on a dataset of the type raster.

In addition, this PR makes sure that when restoring a raster dataset, the editor switches automatically to the map visualization.

## Testing instructions

1. Restore this dataset: [https://api.resourcewatch.org/v1/dataset/b75d8398-34f2-447d-832d-ea570451995a](https://api.resourcewatch.org/v1/dataset/b75d8398-34f2-447d-832d-ea570451995a)

The editor must not crash, and the default visualisation must be a map with a dark basemap and white labels.

2. Restore this widget: [https://api.resourcewatch.org/v1/widget/1ae4b9db-93b9-4b2f-8bdb-b9341627703d](https://api.resourcewatch.org/v1/widget/1ae4b9db-93b9-4b2f-8bdb-b9341627703d)

The editor must not crash, and the widget must be loaded correctly (same layer as the previous test, though the basemap and labels may be different).

## Pivotal Tracker

Not tracked. Reported by Andrés on Slack.
