### PR TITLE
Fix a bug where the horizontal bars could overlap the Y axis

### DIFF
--- a/src/packages/core/src/charts/bars-horizontal.ts
+++ b/src/packages/core/src/charts/bars-horizontal.ts
@@ -80,8 +80,9 @@ export default class BarsHorizontal extends ChartsCommon implements Charts.Bars 
                   : "truncate(data('table')[datum.value - 1].x, 12)",
               },
               align: {
-                signal:
-                  "width < 300 || data('table')[0].count > 10 ? 'right' : 'center'",
+                // If the value isn't right, vega will display the marks on top of the axis. It
+                // seems to be a bug of the library, though I could not find an issue mentioning it.
+                value: "right",
               },
               baseline: {
                 signal:


### PR DESCRIPTION
This PR fixes an issue where the horizontal bars could overlap the Y axis. The issue seems to be located in Vega, but a simple workaround can be implemented. Unfortunately, the widgets created prior to fix this will need to be migrated.

## Testing instructions

1. Open the playground
2. Select the “Bars” visualisation (horizontal bars)
3. Select “Country” on the Y axis and “Forest Sector Employment as Share of Total Workforce” on the X axis

The bars must not overlap the Y axis.

4. Limit the number of rows to less than or equal to 10.

This case was the one failing. Make sure the bars don't overlap the axis.

## Pivotal Tracker

Reported on Slack by Andrés.
