### PR TITLE
add data property logic for no data view

### DIFF
--- a/src/applications/renderer/src/components/renderer/component.js
+++ b/src/applications/renderer/src/components/renderer/component.js
@@ -39,7 +39,7 @@ const Renderer = ({
     isMap
   );
 
-  const { widgetData, dataURL, isErrorData } = useWidgetData(
+  const { widgetData, isLoadingWidgetData, dataURL, isErrorData } = useWidgetData(
     widgetConfig,
     isMap
   );
@@ -67,7 +67,7 @@ const Renderer = ({
     && chartWidgetConfig?.legend?.length > 0
     && !thumbnail;
 
-  const hasNoData = dataURL && (!widgetData || widgetData?.length === 0);
+  const hasNoData = dataURL && !isLoadingWidgetData && (!widgetData || widgetData?.length === 0);
 
   if (isLoadingLayers) {
     return "Loading...";

--- a/src/applications/renderer/src/components/renderer/fetch-data-hook.js
+++ b/src/applications/renderer/src/components/renderer/fetch-data-hook.js
@@ -1,4 +1,5 @@
 import find from 'lodash/find';
+import has from 'lodash/has';
 import { useState, useEffect } from "react";
 
 function getDataUrl(data) {
@@ -6,8 +7,15 @@ function getDataUrl(data) {
   return find(data, 'url')?.url
 }
 
+function getDataProperty(data) {
+  if (!data) return null;
+  return find(data, 'url')?.format?.property
+}
+
 const useWidgetData = (widgetConfig, isMap) => {
   const [dataURL] = useState(getDataUrl(widgetConfig?.data));
+  const [dataProperty] = useState(getDataProperty(widgetConfig?.data));
+
   const [widgetData, setData] = useState(null);
   const [isLoadingWidgetData, setIsLoading] = useState(false);
   const [isErrorData, setIsError] = useState(false);
@@ -19,7 +27,11 @@ const useWidgetData = (widgetConfig, isMap) => {
       try {
         const request = await fetch(dataURL);
         const { data } = await request.json();
-        setData(data);
+        if (dataProperty && has(data, dataProperty)) {
+          setData(data[dataProperty]);
+        } else {
+          setData(data);
+        }
       } catch (error) {
         setIsError(true);
       }
@@ -28,7 +40,7 @@ const useWidgetData = (widgetConfig, isMap) => {
     if (!isMap && dataURL) {
       fetchData();
     }
-  }, [dataURL, isMap]);
+  }, [dataURL, dataProperty, isMap]);
   return { widgetData, dataURL, isLoadingWidgetData, isErrorData };
 };
 


### PR DESCRIPTION
This pr fixes an issue for when we need to check for widget data property sent from widget config, so we know when to check for length. https://gist.github.com/andresgnlez/8c2b3f33693245853159447d8f9ef3e6 example widget. 

We keep the old logic for widgets that dont have this.